### PR TITLE
Add support for generating UI config files

### DIFF
--- a/ui/combine_linker_configs.py
+++ b/ui/combine_linker_configs.py
@@ -1,0 +1,77 @@
+#!/usr/bin/python
+
+# @file gen_makefile.py
+#
+#     Python function to auto generate files used to build kernel modules
+#
+#     @author Trevor Vannoy
+#     @date 2020
+#     @copyright 2020 Flat Earth Inc
+#
+#     THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+#     INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR
+#     PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE
+#     FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+#     ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+#
+#     Trevor Vannoy
+#     Flat Earth Inc
+#     985 Technology Blvd
+#     Bozeman, MT 59718
+#     support@flatearthinc.com
+
+import json
+import argparse
+
+def main(configs, outfile='linker.json', verbose=False):
+    """
+    Combine multiple linker json files into one.
+
+    Each linker json file is an object of one or more objects
+    representing a device driver interface for a given IP core.
+    This function combines each of these objects such that the output 
+    is an object containing all of the device driver interface objects.
+
+    Inputs:
+        configs = list of linker json filenames
+        outfile = name of the output linker json file
+        verbose = verbose printing
+    """
+    combined = {}
+
+    for config in configs:
+        config_dict = json.load(open(config))
+        for key in config_dict.keys():
+            if verbose:
+                print('adding {} to linker'.format(key))
+            combined[key] = config_dict[key]
+
+    if verbose:
+        print('\n')
+        print(json.dumps(combined, indent=4, sort_keys=True))
+
+    if verbose:
+        print('\n')
+        print('wrote new linker file: ' + outfile)
+    json.dump(combined, open(outfile, 'w'), indent=4, sort_keys=True)
+
+
+def parseargs():
+    """
+    Parse commandline input arguments.
+    """
+    parser = argparse.ArgumentParser(description=\
+        "Combine multiple linker json files into one")
+    parser.add_argument('configs',
+        help="list of linker files to combine", nargs='+')
+    parser.add_argument('-o', '--outfile',
+        help="name of combined linker json file", default='linker.json')
+    parser.add_argument('-v', '--verbose', action='store_true', 
+        help="verbose output")
+    args = parser.parse_args()
+    return (args.configs, args.outfile, args.verbose)
+
+
+if __name__ == "__main__":
+    (configs, outfile, verbose) = parseargs()
+    main(configs, outfile, verbose)

--- a/ui/combine_linker_configs.py
+++ b/ui/combine_linker_configs.py
@@ -1,8 +1,8 @@
 #!/usr/bin/python
 
-# @file gen_makefile.py
+# @file combine_linker_configs.py
 #
-#     Python function to auto generate files used to build kernel modules
+#     Script to combine multiple linker json files into one file
 #
 #     @author Trevor Vannoy
 #     @date 2020
@@ -40,11 +40,9 @@ def main(configs, outfile='linker.json', verbose=False):
     combined = {}
 
     for config in configs:
-        config_dict = json.load(open(config))
-        for key in config_dict.keys():
-            if verbose:
-                print('adding {} to linker'.format(key))
-            combined[key] = config_dict[key]
+        with open(config) as fd:
+            config_dict = json.load(fd)
+            combined.update(config_dict)
 
     if verbose:
         print('\n')

--- a/ui/combine_linker_configs.py
+++ b/ui/combine_linker_configs.py
@@ -23,7 +23,7 @@
 import json
 import argparse
 
-def main(configs, outfile='linker.json', verbose=False):
+def main(configs, outfile='Linker.json', verbose=False):
     """
     Combine multiple linker json files into one.
 
@@ -63,7 +63,7 @@ def parseargs():
     parser.add_argument('configs',
         help="list of linker files to combine", nargs='+')
     parser.add_argument('-o', '--outfile',
-        help="name of combined linker json file", default='linker.json')
+        help="name of combined linker json file", default='Linker.json')
     parser.add_argument('-v', '--verbose', action='store_true', 
         help="verbose output")
     args = parser.parse_args()

--- a/ui/combine_ui_configs.py
+++ b/ui/combine_ui_configs.py
@@ -1,0 +1,106 @@
+#!/usr/bin/python
+
+# @file combine_ui_configs.py
+#
+#   Script to combine multiple UI json files into one file
+#    
+#   @author Trevor Vannoy
+#   @date 2020
+#   @copyright 2020 Flat Earth Inc
+#
+#   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+#   INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR
+#   PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE
+#   FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+#   ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+#
+#   Trevor Vannoy
+#   Flat Earth Inc
+#   985 Technology Blvd
+#   Bozeman, MT 59718
+#   support@flatearthinc.com
+
+import json
+import argparse
+
+def main(configs, module_name, outfile='UI.json', verbose=False):
+    """
+    Combine multiple UI json files into one.
+
+    Each UI json file contains a list of pages, each of which has a name and a list panels. 
+    Each panel has a name and a list of controls. This function merges pages, panels, and 
+    controls from multiple UI json files into one json file that can be used to configure
+    a GUI with the UI elements from each UI json file.
+
+    Inputs:
+        configs     = list of linker json filenames
+        module_name = UI module name (what the UI represents), e.g. hearing aid 
+        outfile     = name of the output linker json file
+        verbose     = verbose printing
+    """
+    combined = {'module': module_name, 'pages': []}
+    
+    # lambda functions to get lists of page and panel names
+    page_names = lambda: [combined['pages'][i]['name'] for i in range(len(combined['pages']))] 
+    panel_names = lambda m :[combined['pages'][m]['panels'] for i in range(len(combined['pages'][m]['panels']))]
+
+    for config in configs:
+        with open(config) as fd:
+            config_dict = json.load(fd)
+            for page in config_dict['pages']:
+                try:
+                    # check if the page exists in the combined config
+                    page_idx = page_names().index(page['name'])
+
+                    # page exists, so loop through all panels in the page
+                    for panel in page['panels']:
+                        try:
+                            # check if panel exists in the combined config
+                            panel_idx = panel_names(page_idx).index(panel['name'])
+
+                            # panel already exists, so add register controls to the controls list
+                            combined['pages'][page_idx]['panels'][panel_idx]['controls'].extend(panel['controls'])
+                            if verbose:
+                                print('adding controls to panel {}'.format(panel['name']))
+                        except ValueError:
+                            # panel isn't in the page, so add it
+                            combined['pages'][page_idx]['panels'].append(panel)
+                            if verbose:
+                                print('adding panel {}'.format(panel['name']))
+                except ValueError:
+                    # page isn't in the combined dictionary, so add it
+                    combined['pages'].append(page)
+                    if verbose:
+                        print('adding page {}'.format(page['name']))
+
+    if verbose:
+        print('\n')
+        print(json.dumps(combined, indent=4, sort_keys=True))
+
+    if verbose:
+        print('\n')
+        print('wrote new UI file: ' + outfile)
+    json.dump(combined, open(outfile, 'w'), indent=4, sort_keys=True)
+
+
+def parseargs():
+    """
+    Parse commandline input arguments.
+    """
+    parser = argparse.ArgumentParser(description=\
+        "Combine multiple UI json files into one")
+    parser.add_argument('module_name', 
+        help="what the UI represents (e.g. hearing aid, multi-effects, etc.)")
+    parser.add_argument('configs',
+        help="list of UI files to combine", nargs='+')
+    parser.add_argument('-o', '--outfile',
+        help="name of combined UI json file", default='UI.json')
+    parser.add_argument('-v', '--verbose', action='store_true', 
+        help="verbose output")
+    args = parser.parse_args()
+    return (args.configs, args.module_name, args.outfile, args.verbose)
+
+
+if __name__ == "__main__":
+    (configs, module_name, outfile, verbose) = parseargs()
+    main(configs, module_name, outfile, verbose)

--- a/ui/createLinkerWidgetNames.m
+++ b/ui/createLinkerWidgetNames.m
@@ -1,3 +1,28 @@
+% createLinkerWidgetNames Create the widget names used in the UI and linker configs for each register
+%
+% mp = createLinkerWidgetNames(mp)
+%
+% To avoid name conflicts between different devices/models, the widget names 
+% are of the form <ui element type><#><model name>, e.g. toggle1flanger, slider3bitcrusher, etc.
+%
+% Inputs:
+%   mp = simulink model parameters struct
+% Outputs:
+%   mp = simulink model parameters struct, with widget names for each register added
+
+% Copyright 2020 Flat Earth Inc, Montana State University
+%
+% THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+% INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR
+% PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE
+% FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+% ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+%
+% Trevor Vannoy
+% Flat Earth Inc
+% 985 Technology Blvd
+% Bozeman, MT 59718
+% support@flatearthinc.com
 function mp = createLinkerWidgetNames(mp)
 
 numWidgets = containers.Map();

--- a/ui/createLinkerWidgetNames.m
+++ b/ui/createLinkerWidgetNames.m
@@ -1,0 +1,18 @@
+function mp = createLinkerWidgetNames(mp)
+
+numWidgets = containers.Map();
+for i = 1:length(mp.register)
+    % keep track of how many registers have a given widget type so 
+    % we can increment the widget name accordingly
+    widgetType = mp.register(i).widget_type;
+    if numWidgets.isKey(widgetType)
+        numWidgets(widgetType) = numWidgets(widgetType) + 1;
+    else
+        numWidgets(widgetType) = 1;
+    end
+
+    % widget name is of the form: slider<#><model name>
+    widgetName = [widgetType, num2str(numWidgets(widgetType)), mp.model_name];
+    mp.register(i).widget_name = widgetName;
+
+end

--- a/ui/createLinkerWidgetNames.m
+++ b/ui/createLinkerWidgetNames.m
@@ -29,7 +29,7 @@ numWidgets = containers.Map();
 for i = 1:length(mp.register)
     % keep track of how many registers have a given widget type so 
     % we can increment the widget name accordingly
-    widgetType = mp.register(i).widget_type;
+    widgetType = mp.register(i).widgetType;
     if numWidgets.isKey(widgetType)
         numWidgets(widgetType) = numWidgets(widgetType) + 1;
     else
@@ -38,6 +38,6 @@ for i = 1:length(mp.register)
 
     % widget name is of the form: slider<#><model name>
     widgetName = [widgetType, num2str(numWidgets(widgetType)), mp.model_name];
-    mp.register(i).widget_name = widgetName;
+    mp.register(i).widgetName = widgetName;
 
 end

--- a/ui/genLinkerConfig.m
+++ b/ui/genLinkerConfig.m
@@ -34,7 +34,7 @@ links = struct();
 
 % map widget name to sysfs file
 for register = mp.register
-    links.(register.widgetName) = ['/', register.name];
+    links.(register.widgetName) = ['/', lower(register.name)];
 end
 
 linkerConfig.(mp.model_name).links = links;

--- a/ui/genLinkerConfig.m
+++ b/ui/genLinkerConfig.m
@@ -1,0 +1,55 @@
+% genLinkerConfig Generate linker json file
+%
+% genLinkerConfig(mp, outfile)
+%
+% The linker json file tells our node js server on the HPS where 
+% registers for a device driver are located in sysfs. This function
+% generates a linker file for the model represented by mp. If 
+% multiple models are to be run on the FPGA, use combine_linker_configs.py
+% to combine linker files for all models of interest.
+%
+% Inputs:
+%   mp = simulink model parameters struct
+%   outfile = name of the output linker json file
+
+% Copyright 2020 Flat Earth Inc, Montana State University
+%
+% THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+% INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR
+% PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE
+% FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+% ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+%
+% Trevor Vannoy
+% Flat Earth Inc
+% 985 Technology Blvd
+% Bozeman, MT 59718
+% support@flatearthinc.com
+
+function genLinkerConfig(mp, outfile)
+linkerConfig = struct(mp.model_name, struct());
+linkerConfig.(mp.model_name).majorNo = "*";
+
+links = struct();
+
+numWidgets = containers.Map();
+
+for register = mp.register
+    % keep track of how many registers have a given widget type so 
+    % we can increment the widget name accordingly
+    widgetType = register.widget_type;
+    if numWidgets.isKey(widgetType)
+        numWidgets(widgetType) = numWidgets(widgetType) + 1;
+    else
+        numWidgets(widgetType) = 1;
+    end
+
+    % widget name is of the form: slider<#><model name>
+    widgetname = [widgetType, num2str(numWidgets(widgetType)), mp.model_name];
+
+    links.(widgetname) = ['/', register.name];
+end
+
+linkerConfig.(mp.model_name).links = links;
+
+writejson(linkerConfig, outfile);

--- a/ui/genLinkerConfig.m
+++ b/ui/genLinkerConfig.m
@@ -32,22 +32,9 @@ linkerConfig.(mp.model_name).majorNo = "*";
 
 links = struct();
 
-numWidgets = containers.Map();
-
+% map widget name to sysfs file
 for register = mp.register
-    % keep track of how many registers have a given widget type so 
-    % we can increment the widget name accordingly
-    widgetType = register.widget_type;
-    if numWidgets.isKey(widgetType)
-        numWidgets(widgetType) = numWidgets(widgetType) + 1;
-    else
-        numWidgets(widgetType) = 1;
-    end
-
-    % widget name is of the form: slider<#><model name>
-    widgetname = [widgetType, num2str(numWidgets(widgetType)), mp.model_name];
-
-    links.(widgetname) = ['/', register.name];
+    links.(register.widget_name) = ['/', register.name];
 end
 
 linkerConfig.(mp.model_name).links = links;

--- a/ui/genLinkerConfig.m
+++ b/ui/genLinkerConfig.m
@@ -34,7 +34,7 @@ links = struct();
 
 % map widget name to sysfs file
 for register = mp.register
-    links.(register.widget_name) = ['/', register.name];
+    links.(register.widgetName) = ['/', register.name];
 end
 
 linkerConfig.(mp.model_name).links = links;

--- a/ui/genUiConfig.m
+++ b/ui/genUiConfig.m
@@ -34,8 +34,8 @@ uiConfig.module = mp.model_name;
 
 % create the first page and panel
 registerControls = createControlObject(mp.register(1));
-pageName = mp.register(1).uiPageName;
-panelName = mp.register(1).uiPanelName;
+pageName = formatTitle(mp.register(1).uiPageName);
+panelName = formatTitle(mp.register(1).uiPanelName);
 controls = {registerControls};
 panel = {struct('name', panelName)};
 panel{1}.controls = controls;
@@ -46,8 +46,8 @@ uiConfig.pages = {struct('name', pageName, 'panels', ...
 % add the rest of the registers to the UI config
 for i=2:length(mp.register)
     registerControls = createControlObject(mp.register(i));
-    pageName = mp.register(i).uiPageName;
-    panelName = mp.register(i).uiPanelName;
+    pageName = formatTitle(mp.register(i).uiPageName);
+    panelName = formatTitle(mp.register(i).uiPanelName);
 
     % check if the desired page already exists
     pageIdx = findFieldValue(uiConfig.pages, 'name', pageName);
@@ -103,6 +103,7 @@ controlObject.dataType = register.dataType.qpointstr;
 controlObject.defaultValue = register.default;
 controlObject.units = register.widgetDisplayUnits;
 controlObject.style = register.widgetStyle;
+controlObject.title = formatTitle(register.name);
 end
 
 function idx = findFieldValue(arrayOfStruct, field, value)
@@ -129,3 +130,19 @@ for i = 1:length(arrayOfStruct)
     end
 end
 end
+
+function s = formatTitle(str)
+    % split string into words
+    words = split(str, [" " "_" "-"]);
+
+    % capitalize each word
+    words = cellfun(@(s) [upper(s(1)) s(2:end)], words, 'uniformoutput', false);
+
+    % put the words back together with spaces in between
+    s = join(words, ' ');
+
+    % turn cell array into character array (string)
+    s = s{:};
+end
+
+    

--- a/ui/genUiConfig.m
+++ b/ui/genUiConfig.m
@@ -23,26 +23,45 @@
 
 function genUiConfig(mp, outfile)
 uiConfig.module = mp.model_name;
-uiConfig.pages = containers.Map();
 
-for register = mp.register
-    registerControls = createControlObject(register);
+% create the first page and panel
+registerControls = createControlObject(mp.register(1));
+pageName = mp.register(1).uiPageName;
+panelName = mp.register(1).uiPanelName;
+panel = {struct('name', panelName, 'controls', registerControls)};
+uiConfig.pages = {struct('name', pageName, 'panels', ...
+    {panel})};
+    
 
-    page = register.ui_page;
-    panelName = register.ui_effect_name;
-    if uiConfig.pages.isKey(page)
-        % page exists, so check if the desired "effect" panel exists
-        if uiConfig.pages(page).isKey(panelName)
-            panels = uiConfig.pages(page);
-            % add register to existing effect panel
-            panels(panelName) = [panels(panelName), registerControls];
+% add the rest of the registers to the UI config
+for i=2:length(mp.register)
+    registerControls = createControlObject(mp.register(i));
+    pageName = mp.register(i).uiPageName;
+    panelName = mp.register(i).uiPanelName;
+
+    % check if the desired page already exists
+    pageIdx = findFieldValue(uiConfig.pages, 'name', pageName);
+    if pageIdx
+        % page exists, so check if the desired panel exists
+        panelIdx = findFieldValue(uiConfig.pages{pageIdx}.panels, 'name', panelName);
+        if panelIdx
+            % add register to existing panel
+            % NOTE: apparently appending to a cell array doesn't work quite like 
+            %       appending to a normal array. a = {..., ...}; a = {a, ...} DOES NOT
+            %       behave the same as a = [..., ...]; a = [a, ...]. Maybe that's not 
+            %       even a good way to append to normal arrays either... 
+            %       To append to a cell array, you need to index into a new cell
+            registerIdx = length(uiConfig.pages{pageIdx}.panels{panelIdx}.controls) + 1;
+            uiConfig.pages{pageIdx}.panels{panelIdx}.controls(registerIdx) = registerControls;
         else
-            % effect panel doesn't exist, so create one
-            panels(panelName) = registerControls;
+            % panel doesn't exist, so create one and add the register controls
+            uiConfig.pages{pageIdx}.panels = {uiConfig.pages{pageIdx}.panels, ...
+                struct('name', panelName, 'controls', registerControls)};
         end
     else
-        % page doesn't exist, so create a new page and an "effect" panel
-        uiConfig.pages(page) = containers.Map(panelName, registerControls);
+        % page doesn't exist, so create a new page and panel for the register controls
+        uiConfig.pages = {uiConfig.pages struct('name', pageName, 'panels', ...
+            struct('name', panelName, 'controls', registerControls))};
     end
 end
         
@@ -53,9 +72,19 @@ end
 function controlObject = createControlObject(register)
 controlObject.linkerName = register.widget_name;
 controlObject.type = register.widget_type;
-controlObject.range = [num2str(register.min) '-' num2str(register.max)];
+controlObject.min = register.min;
+controlObject.max = register.max;
+controlObject.dataType = register.dataType.qpointstr;
 controlObject.defaultValue = register.default;
 controlObject.units = register.widget_display_units;
 controlObject.style = register.widget_style;
 end
 
+function idx = findFieldValue(arrayOfStruct, field, value)
+idx = 0;
+for i = 1:length(arrayOfStruct)
+    if strcmpi(arrayOfStruct{i}.(field), value)
+        idx = i;
+    end
+end
+end

--- a/ui/genUiConfig.m
+++ b/ui/genUiConfig.m
@@ -95,14 +95,14 @@ function controlObject = createControlObject(register)
 %   register = register struct from Simulink model init scripts
 % Outputs:
 %   controlObject = register info packed into a struct for json UI config file
-controlObject.linkerName = register.widget_name;
-controlObject.type = register.widget_type;
+controlObject.linkerName = register.widgetName;
+controlObject.type = register.widgetType;
 controlObject.min = register.min;
 controlObject.max = register.max;
 controlObject.dataType = register.dataType.qpointstr;
 controlObject.defaultValue = register.default;
-controlObject.units = register.widget_display_units;
-controlObject.style = register.widget_style;
+controlObject.units = register.widgetDisplayUnits;
+controlObject.style = register.widgetStyle;
 end
 
 function idx = findFieldValue(arrayOfStruct, field, value)

--- a/ui/genUiConfig.m
+++ b/ui/genUiConfig.m
@@ -22,6 +22,14 @@
 % support@flatearthinc.com
 
 function genUiConfig(mp, outfile)
+% NOTE: to get jsonencode to create lists when there is only one struct, 
+%       I had to use cell arrays instead of normal arrays. A scalar is the same as a 
+%       1x1 array, so that all makes sense. Creating the cell arrays seemed to work 
+%       best when I created the cell array outside of the struct constructor. 
+%       Essentially, I needed a cell array of [1x1 structs] so jsonencode
+%       would create the intended data structure. The data structure creation 
+%       in this function could probably be cleaner...
+
 uiConfig.module = mp.model_name;
 
 % create the first page and panel
@@ -77,6 +85,16 @@ end
 
     
 function controlObject = createControlObject(register)
+% createControlObject Assemble register info into a struct
+%
+% controlObject = createControlObject(register)
+%
+% This function essentially just renames some fields in the register struct
+%
+% Inputs:
+%   register = register struct from Simulink model init scripts
+% Outputs:
+%   controlObject = register info packed into a struct for json UI config file
 controlObject.linkerName = register.widget_name;
 controlObject.type = register.widget_type;
 controlObject.min = register.min;
@@ -88,6 +106,22 @@ controlObject.style = register.widget_style;
 end
 
 function idx = findFieldValue(arrayOfStruct, field, value)
+% findFieldValue Find a field value in an array of structs
+%
+% idx = findFieldValue(arrayOfStruct, field, value)
+%
+% This function loops through an array of structures, looks at
+% the given field in each struct, and sees if the given value
+% is in any of the structs. If so, it returns the index where that is
+% is true, otherwise the index is 0.
+% 
+% Inputs:
+%   arrayOfStruct = array of structures to loop through
+%   field = the field to look at in each struct
+%   value = the value to look for
+%
+% Outputs:
+%   idx = the index where the field was found
 idx = 0;
 for i = 1:length(arrayOfStruct)
     if strcmpi(arrayOfStruct{i}.(field), value)

--- a/ui/genUiConfig.m
+++ b/ui/genUiConfig.m
@@ -28,7 +28,9 @@ uiConfig.module = mp.model_name;
 registerControls = createControlObject(mp.register(1));
 pageName = mp.register(1).uiPageName;
 panelName = mp.register(1).uiPanelName;
-panel = {struct('name', panelName, 'controls', registerControls)};
+controls = {registerControls};
+panel = {struct('name', panelName)};
+panel{1}.controls = controls;
 uiConfig.pages = {struct('name', pageName, 'panels', ...
     {panel})};
     
@@ -52,16 +54,21 @@ for i=2:length(mp.register)
             %       even a good way to append to normal arrays either... 
             %       To append to a cell array, you need to index into a new cell
             registerIdx = length(uiConfig.pages{pageIdx}.panels{panelIdx}.controls) + 1;
-            uiConfig.pages{pageIdx}.panels{panelIdx}.controls(registerIdx) = registerControls;
+            uiConfig.pages{pageIdx}.panels{panelIdx}.controls{registerIdx} = registerControls;
         else
             % panel doesn't exist, so create one and add the register controls
-            uiConfig.pages{pageIdx}.panels = {uiConfig.pages{pageIdx}.panels, ...
-                struct('name', panelName, 'controls', registerControls)};
+            panelIdx = length(uiConfig.pages{pageIdx}.panels) + 1;
+            panel = {struct('name', panelName)};
+            panel{1}.controls = {registerControls};
+            uiConfig.pages{pageIdx}.panels{panelIdx} = panel{1};
+            
         end
     else
         % page doesn't exist, so create a new page and panel for the register controls
-        uiConfig.pages = {uiConfig.pages struct('name', pageName, 'panels', ...
-            struct('name', panelName, 'controls', registerControls))};
+        panel = {struct('name', panelName)};
+        panel{1}.controls = {registerControls};
+        pageIdx = length(uiConfig.pages) + 1;
+        uiConfig.pages{pageIdx} = struct('name', pageName, 'panels', {panel});
     end
 end
         

--- a/ui/genUiConfig.m
+++ b/ui/genUiConfig.m
@@ -1,0 +1,61 @@
+% genUiConfig Generate json file used to autogenerate gui
+%
+% genUiConfig(mp, outfile)
+%
+%
+% Inputs:
+%   mp = simulink model parameters struct
+%   outfile = name of the output linker json file
+
+% Copyright 2020 Flat Earth Inc, Montana State University
+%
+% THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+% INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR
+% PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE
+% FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+% ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+%
+% Trevor Vannoy
+% Flat Earth Inc
+% 985 Technology Blvd
+% Bozeman, MT 59718
+% support@flatearthinc.com
+
+function genUiConfig(mp, outfile)
+uiConfig.module = mp.model_name;
+uiConfig.pages = containers.Map();
+
+for register = mp.register
+    registerControls = createControlObject(register);
+
+    page = register.ui_page;
+    panelName = register.ui_effect_name;
+    if uiConfig.pages.isKey(page)
+        % page exists, so check if the desired "effect" panel exists
+        if uiConfig.pages(page).isKey(panelName)
+            panels = uiConfig.pages(page);
+            % add register to existing effect panel
+            panels(panelName) = [panels(panelName), registerControls];
+        else
+            % effect panel doesn't exist, so create one
+            panels(panelName) = registerControls;
+        end
+    else
+        % page doesn't exist, so create a new page and an "effect" panel
+        uiConfig.pages(page) = containers.Map(panelName, registerControls);
+    end
+end
+        
+writejson(uiConfig, outfile);
+end
+
+    
+function controlObject = createControlObject(register)
+controlObject.linkerName = register.widget_name;
+controlObject.type = register.widget_type;
+controlObject.range = [num2str(register.min) '-' num2str(register.max)];
+controlObject.defaultValue = register.default;
+controlObject.units = register.widget_display_units;
+controlObject.style = register.widget_style;
+end
+

--- a/vhdl/vgen_get_simulink_block_interfaces.m
+++ b/vhdl/vgen_get_simulink_block_interfaces.m
@@ -99,7 +99,7 @@ if (isempty(register_names)==0) % The avalon memory mapped interface exists
             p=get_param(h,'CompiledPortDataTypes');
             register_name = get(h,'PortName');
             register_name = register_name(length('register_control_')+1:end);  % remove "register_control_" from name
-            avalon1.avalon_memorymapped.register{index}.name      = register_name;
+            avalon1.avalon_memorymapped.register{index}.name      = lower(register_name);
             avalon1.avalon_memorymapped.register{index}.data_type = parse_data_type(p.Outport{1});
             % register numbers start at 0, so we have to subtract 1
             avalon1.avalon_memorymapped.register{index}.reg_num   = index - 1;

--- a/vhdl/vgen_process_simulink_model.m
+++ b/vhdl/vgen_process_simulink_model.m
@@ -63,6 +63,10 @@ avalon.linux_device_version = mp.linux_device_version;
 writejson(avalon, [avalon.entity,'.json'])
 save([avalon.entity '_avalon'], 'avalon')
 
+%% Create UI config files
+disp('Creating linker json file.')
+genLinkerConfig(mp, ['linker_', mp.model_name, '.json'])
+
 %% Generate the Simulink model VHDL code
 
 % run the hdl coder

--- a/vhdl/vgen_process_simulink_model.m
+++ b/vhdl/vgen_process_simulink_model.m
@@ -66,7 +66,7 @@ save([avalon.entity '_avalon'], 'avalon')
 %% Create UI config files
 disp('Creating linker json file.')
 mp = createLinkerWidgetNames(mp);
-genLinkerConfig(mp, ['linker_', mp.model_name, '.json']);
+genLinkerConfig(mp, ['Linker_', mp.model_name, '.json']);
 disp('Creating UI config json file.')
 genUiConfig(mp, ['UI_', mp.model_name, '.json']);
 

--- a/vhdl/vgen_process_simulink_model.m
+++ b/vhdl/vgen_process_simulink_model.m
@@ -65,7 +65,10 @@ save([avalon.entity '_avalon'], 'avalon')
 
 %% Create UI config files
 disp('Creating linker json file.')
-genLinkerConfig(mp, ['linker_', mp.model_name, '.json'])
+mp = createLinkerWidgetNames(mp);
+genLinkerConfig(mp, ['linker_', mp.model_name, '.json']);
+disp('Creating UI config json file.')
+genUiConfig(mp, ['UI_', mp.model_name, '.json']);
 
 %% Generate the Simulink model VHDL code
 
@@ -107,16 +110,21 @@ disp(['      created Kbuild: ' [hdlpath filesep 'Kbuild']])
 %       use a virtual machine to compile the device driver, but that
 %       won't automate very well. Maybe we can build the kernel module 
 %       with Quartus' embedded command shell instead?
-disp('Building kernel module.')
-cd(hdlpath)
-!make clean
-!make ARCH=arm CROSS_COMPILE=arm-linux-gnueabihf- 
+if isunix
+    disp('Building kernel module.')
+    cd(hdlpath)
+    !make clean
+    !make ARCH=arm CROSS_COMPILE=arm-linux-gnueabihf- 
+else
+    disp('Kernel module needs to be manually built in a Linux environment.')
 
 % TODO: this file now generates C code, but "vgen" make it seem like it is just VHDL still. This should be changed, and the repository should be reorganized a bit. 
 %       This file shouldn't live in the vhdl folder anymore.
 
 
 disp('vgen: Finished.')
+
+cd(mp.model_path)
 
 % reset fast simulation flag so running the model simulation isn't so slow after generating code. 
 mp.fastsim_flag = 1;

--- a/vhdl/vgen_process_simulink_model.m
+++ b/vhdl/vgen_process_simulink_model.m
@@ -117,6 +117,7 @@ if isunix
     !make ARCH=arm CROSS_COMPILE=arm-linux-gnueabihf- 
 else
     disp('Kernel module needs to be manually built in a Linux environment.')
+end
 
 % TODO: this file now generates C code, but "vgen" make it seem like it is just VHDL still. This should be changed, and the repository should be reorganized a bit. 
 %       This file shouldn't live in the vhdl folder anymore.

--- a/vhdl/writejson.m
+++ b/vhdl/writejson.m
@@ -34,7 +34,7 @@ collections = py.importlib.import_module('collections');
 jsonstr = jsonencode(data);
 
 % create the pretty-printed json string
-prettyjson = char(py.json.dumps(py.json.loads(jsonstr), pyargs('indent', int32(4))));
+prettyjson = char(py.json.dumps(py.json.loads(jsonstr), pyargs('sort_keys', true, 'indent', int32(4))));
 
 % save the string to a file
 fid = fopen(filename, 'w');


### PR DESCRIPTION
This pull request is directly related to https://github.com/fpga-open-speech-tools/simulink_models/pull/19

This request does two primary things:
1. creates the `linker.json` file that lives on the HPS; this file mediates messages between the UI and the device drivers
2. creates the `UI.json` file that is used to generate a GUI configuration at runtime. 

All of the basic functionality works, at least on the models tested in https://github.com/fpga-open-speech-tools/simulink_models/pull/19

A future pull request will add a **colorscheme** object to the json file, that way users can define the colorscheme of the GUI.  