### PR TITLE
Fixed Driver Removal

### DIFF
--- a/device_drivers/CreateRemoveFunction.py
+++ b/device_drivers/CreateRemoveFunction.py
@@ -5,10 +5,10 @@ def CreateRemoveFunction(inputParams):
     functionString += "static int " + inputParams.deviceName + "_remove(struct platform_device *pdev) {\n"
     functionString += "  fe_" + inputParams.deviceName + "_dev_t *dev = (fe_" + inputParams.deviceName + "_dev_t *)platform_get_drvdata(pdev);\n"
     functionString += "  pr_info(\"" + inputParams.deviceName + "_remove enter\\n\");\n"
+    functionString += "  device_destroy(cl, dev_num);\n"
     functionString += "  cdev_del(&dev->cdev);\n"
+    functionString += "  class_destroy(cl);\n"
     functionString += "  unregister_chrdev_region(dev_num, 2);\n"
-    if inputParams.deviceType == 2:  # FPGA device
-        functionString += "  iounmap(dev->regs);\n"
     functionString += "  pr_info(\"" + inputParams.deviceName + "_remove exit\\n\");\n"
     functionString += "  return 0;\n"
     functionString += "}\n"


### PR DESCRIPTION
Updated driver remove function to fully remove everything device related and removed iounmap because the memory already gets freed.

`class_destroy` removes the `/sys/class/` entry and `device_destroy` handles the rest