### PR TITLE
Update the RBF/DTBO filename to be more descriptive

### DIFF
--- a/vhdl/autogen.m
+++ b/vhdl/autogen.m
@@ -17,7 +17,6 @@ cmd = [bdroot,'([],[],[],''compile'');'];
     catch
     end
 %end
-pe = pyenv;
 pause(5)
 get_param(bdroot,'SimulationStatus')
 vgen_process_simulink_model

--- a/vhdl/quartus/quartus_templates.py
+++ b/vhdl/quartus/quartus_templates.py
@@ -29,7 +29,7 @@ set project project_name
 set target_system target_name
 load_package flow
 
-project_new $project -revision $target_system -overwrite
+project_new $project -revision ${project}_$target_system -overwrite
 
 source ${target_system}_proj.tcl
 

--- a/vhdl/quartus/quartus_workflow.py
+++ b/vhdl/quartus/quartus_workflow.py
@@ -348,8 +348,9 @@ def execute_quartus_workflow(config, working_dir=""):
     gen_qsys_system(target, config, template, working_dir)
 
     project_name = "_".join(config.custom_components)
-    if not(project_with_revision_exists(project_name, project_revision=target.name, working_dir=working_dir)):
+    project_revision = project_name + "_" + target.name
+    if not(project_with_revision_exists(project_name, project_revision=project_revision, working_dir=working_dir)):
         gen_project(project_name, target, template, working_dir)
-        compile_project(project_name, project_revision=target.name, template=template, working_dir=working_dir)
+        compile_project(project_name, project_revision=project_revision, template=template, working_dir=working_dir)
     else:
-        compile_project(project_name, project_revision=target.name, template=template, working_dir=working_dir)
+        compile_project(project_name, project_revision=project_revision, template=template, working_dir=working_dir)

--- a/vhdl/vgen_get_simulink_block_interfaces.m
+++ b/vhdl/vgen_get_simulink_block_interfaces.m
@@ -105,7 +105,7 @@ if (isempty(register_names)==0) % The avalon memory mapped interface exists
             avalon1.avalon_memorymapped.register{index}.reg_num   = index - 1;
             Nregisters = length(model_params.register);
             for j=1:Nregisters
-                 if strcmpi(register_name,model_params.register(j).name)  % get the register with the same name
+                if strcmpi(register_name,model_params.register(j).name)  % get the register with the same name
                     avalon1.avalon_memorymapped.register{index}.default_value = model_params.register(j).default;
                     avalon1.avalon_memorymapped.register{index}.min_value     = model_params.register(j).min;
                     avalon1.avalon_memorymapped.register{index}.max_value     = model_params.register(j).max;

--- a/vhdl/vgen_process_simulink_model.m
+++ b/vhdl/vgen_process_simulink_model.m
@@ -98,7 +98,7 @@ vgenHwTcl(infile, outfile, hdlpath)
 disp(['      created tcl file: ' outfile])
 
 disp('vgen: Executing Quartus workflow')
-%vgenQuartus(infile, hdlpath + "/quartus/")
+vgenQuartus(infile, hdlpath + "/quartus/")
 disp('Executed Quartus workflow')
 
 %% Generate the device driver code

--- a/vhdl/vgen_process_simulink_model.m
+++ b/vhdl/vgen_process_simulink_model.m
@@ -98,7 +98,7 @@ vgenHwTcl(infile, outfile, hdlpath)
 disp(['      created tcl file: ' outfile])
 
 disp('vgen: Executing Quartus workflow')
-vgenQuartus(infile, hdlpath + "/quartus/")
+%vgenQuartus(infile, hdlpath + "/quartus/")
 disp('Executed Quartus workflow')
 
 %% Generate the device driver code
@@ -136,21 +136,21 @@ end
 
 % TODO: this file now generates C code, but "vgen" make it seem like it is just VHDL still. This should be changed, and the repository should be reorganized a bit. 
 %       This file shouldn't live in the vhdl folder anymore.
-
+project_revision = mp.model_name + "_" + mp.target_system;
 try
-    py.generate.generate_device_tree_overlay(hdlpath + "/quartus/" + mp.target_system + '_system.sopcinfo', mp.target_system + '.rbf')
+    py.generate.generate_device_tree_overlay(hdlpath + "/quartus/" + mp.target_system + '_system.sopcinfo', project_revision + '.rbf')
 catch e
     disp(getReport(e))
 end
 
 if ispc
     if system('wsl.exe cd') == 0 
-        system("wsl.exe dtc -@ -O dtb -o " + mp.target_system + ".dtbo " + mp.target_system + ".dts");
+        system("wsl.exe dtc -@ -O dtb -o " + project_revision + ".dtbo " + project_revision + ".dts");
     else
         disp("Windows Subsystem for Linux is currently required to automate compiling device tree overlays")
     end
 elseif isunix
-    system("dtc -@ -O dtb -o " + mp.target_system + ".dtbo " + mp.target_system + ".dts");
+    system("dtc -@ -O dtb -o " + project_revision + ".dtbo " + project_revision + ".dts");
 else
     disp('The current operating system is unsupported for automatically compiling device tree overlays')
 end


### PR DESCRIPTION
Because the rbf filename is based on the project revision, which was set to whatever the target system was, the rbf filename was either `de10.rbf` or `audioblade.rbf`. Now to have more descriptive names for the rbf and dtbo files, the project revision is [model_name]_[target_system] so for example it would be `bitcrusher_de10.rbf`. 

Additionally, beyond just improving the description it means not every overlay on say a de-10 is called de10, making applying the right overlay much easier.