### PR TITLE
Model references support

### DIFF
--- a/autogen_hw_tcl.py
+++ b/autogen_hw_tcl.py
@@ -2,10 +2,11 @@ import argparse
 from ipcore.dataplane_config import DataplaneConfig
 from ipcore.hw_tcl_generator import HwTCLGenerator
 
-def main(inputFilename, outputFilename, additionalFilesetAbsDir):
+def main(inputFilename, outputFilename, additionalFilesetAbsDir, sourceFilePatterns=[]):
+    
     dataplane_config = DataplaneConfig.parse_json(
         additionalFilesetAbsDir + "/../../" + inputFilename)
-    dataplane_config.populate_additional_filesets(additionalFilesetAbsDir)
+    dataplane_config.populate_additional_filesets(additionalFilesetAbsDir, sourceFilePatterns)
     generator = HwTCLGenerator(dataplane_config)
     generator.write_tcl(outputFilename)
 
@@ -19,8 +20,9 @@ def parseargs():
                         help="Working directory to generate the Platform Designer component in")
     parser.add_argument('-o', '--output-filename',
                         help="Name of the output file, recommended to end in '_hw.tcl'")
+    parser.add_argument('-s', '--source-pattern',nargs='+', help='Patterns to find source files from the working directory')
     args = parser.parse_args()
-    return (args.config, args.output_filename, args.working_dir)
+    return (args.config, args.output_filename, args.working_dir, args.source_pattern)
 
 
 if __name__ == "__main__":

--- a/ipcore/avalon_config.py
+++ b/ipcore/avalon_config.py
@@ -43,7 +43,8 @@ class AvalonConfig:
                 json_audio_in["fractionLength"],
                 json_audio_in["signed"]
                 ),
-            json_audio_in["numberOfChannels"]
+            json_audio_in["numberOfChannels"],
+            json_audio_in.get("dual") or False
         )
 
         json_audio_out = modeljson["system"]["audioOut"]
@@ -53,7 +54,8 @@ class AvalonConfig:
                 json_audio_out["fractionLength"],
                 json_audio_out["signed"]
                 ),
-            json_audio_out["numberOfChannels"]
+            json_audio_out["numberOfChannels"],
+            json_audio_out.get("dual") or False
         )
 
         json_registers = modeljson['devices'][0]["registers"]

--- a/ipcore/avalon_wrapper.py
+++ b/ipcore/avalon_wrapper.py
@@ -70,6 +70,12 @@ def generate_avalon_wrapper(registers, audio_in, audio_out, entity_name, working
         Port(PortDir.In, Signal("avalon_slave_write")),
         Port(PortDir.In, Signal("avalon_slave_writedata", 32))
     ]
+
+    if(audio_in.dual):
+        avalon_entity_ports.append(Port(PortDir.In, Signal("avalon_sink_data", 32, None, "std_logic_vector", avalon_in_data_type)))
+    if(audio_out.dual):
+        avalon_entity_ports.append(Port(PortDir.Out, Signal("avalon_source_data", 32, None, "std_logic_vector", avalon_out_data_type)))
+
     avalon_entity = Entity(f"{entity_name}_avalon", avalon_entity_ports)
 
     avalon_architecture = Architecture(
@@ -128,7 +134,7 @@ def generate_avalon_wrapper(registers, audio_in, audio_out, entity_name, working
     ]
 
     if is_sample_based:
-        libraries[0].packages.append(f"{entity_name}_pkg")
+        libraries[1].packages.append(f"{entity_name}_pkg")
 
     avalon_wrapper = EntityFile(
         avalon_entity.name, avalon_entity, avalon_architecture, libraries)

--- a/ipcore/avalon_wrapper.py
+++ b/ipcore/avalon_wrapper.py
@@ -48,6 +48,7 @@ def generate_avalon_wrapper(registers, audio_in, audio_out, entity_name, working
     if addr_width == 0 and len(registers) == 1:
         addr_width = 1
     channel_in_width = int(ceil(log(audio_in.channel_count, 2)))
+    print(channel_in_width)
     channel_out_width = int(ceil(log(audio_out.channel_count, 2)))
 
     avalon_entity_ports = [
@@ -56,12 +57,12 @@ def generate_avalon_wrapper(registers, audio_in, audio_out, entity_name, working
         Port(PortDir.In, Signal("avalon_sink_valid")),
         Port(PortDir.In, Signal("avalon_sink_data", 32,
                                 None, "std_logic_vector", avalon_in_data_type)),
-        Port(PortDir.In, Signal("avalon_sink_channel", channel_in_width, None, "std_logic_vector")),
+        Port(PortDir.In, Signal("avalon_sink_channel", channel_in_width)),
         Port(PortDir.In, Signal("avalon_sink_error", 2)),
         Port(PortDir.Out, Signal("avalon_source_valid")),
         Port(PortDir.Out, Signal("avalon_source_data", 32,
                                  None, "std_logic_vector", avalon_out_data_type)),
-        Port(PortDir.Out, Signal("avalon_source_channel", channel_out_width, None, "std_logic_vector")),
+        Port(PortDir.Out, Signal("avalon_source_channel", channel_out_width)),
         Port(PortDir.Out, Signal("avalon_source_error", 2)),
         Port(PortDir.In, Signal("avalon_slave_address",
                                 addr_width, None, "std_logic_vector")),

--- a/ipcore/dataplane_config.py
+++ b/ipcore/dataplane_config.py
@@ -1,6 +1,7 @@
 import json
 from math import ceil, log
 import os
+import re
 from collections import namedtuple
 
 
@@ -21,10 +22,24 @@ class DataplaneConfig:
         self.sink_max_channel = 0
         self.source_max_channel = 0
 
-    def populate_additional_filesets(self, additionalFilesetAbsDir):
-        for filename in os.listdir(additionalFilesetAbsDir):
-            if filename.endswith(".vhd") and '_avalon' not in filename and (self.name in filename or "pkg" in filename):
-                self.additional_filesets.append(filename)
+    def populate_additional_filesets(self, additionalFilesetAbsDir, sourceFilePatterns):
+        for pattern in sourceFilePatterns:
+            
+            subdirectories = pattern.split('\\\\')[0:-1]
+            regex = pattern.split('\\\\')[-1]
+            subdirectory_path = "\\".join(subdirectories)
+            search_path = additionalFilesetAbsDir + "\\" + subdirectory_path
+            
+            matchingFiles = []
+            for filename in os.listdir(search_path):
+                if (re.match(regex, filename) and not(filename in self.additional_filesets)):
+                    if len(subdirectories) > 0:
+                        filepath = subdirectory_path + "\\\\" + filename
+                    else:
+                        filepath = filename
+                    matchingFiles.append(filepath)
+            self.additional_filesets.extend(matchingFiles)
+
 
     @staticmethod
     def parse_json(inputFilename, deviceIndex=0):

--- a/ipcore/util.py
+++ b/ipcore/util.py
@@ -2,7 +2,7 @@ from math import fabs
 import collections
 
 Register = collections.namedtuple('Register', ['name', 'data_type', 'default'])
-Audio = collections.namedtuple('Audio', ['data_type', 'channel_count'])
+Audio = collections.namedtuple('Audio', ['data_type', 'channel_count', 'dual'])
 DataType = collections.namedtuple(
     'DataType', ['word_len', 'frac_len', 'signed'])
 

--- a/ipcore/vhdl_node.py
+++ b/ipcore/vhdl_node.py
@@ -95,7 +95,8 @@ class EntityFile(VHDLFile):
 class Signal(BaseVHDLNode):
     def __init__(self, name, length=1, default_value=None, data_type=None, underlying_data_type=None):
         super().__init__(name)
-        self.length = length
+        
+        self.length = length or 1
         self.default_value = default_value
 
         if data_type is None:

--- a/vgen_process_simulink_model.m
+++ b/vgen_process_simulink_model.m
@@ -78,26 +78,12 @@ disp(['      created vhdl file: ' outfile])
 disp('vgen: Creating .tcl script for Platform Designer.')
 % NOTE: platform designer only adds components if they have the _hw.tcl suffix
 outfile = [hdlpath filesep mp.modelName '_dataplane_avalon_hw.tcl'];
-<<<<<<< HEAD
-
-hw_tcl_cmd = python + mp.codegen_path + filesep + "autogen_hw_tcl.py -c " + config_file + " -w " + hdlpath + " -o " + outfile;
-=======
-<<<<<<< Updated upstream
-disp(['file ' config_filepath ' out ' outfile ' path ' hdlpath])
-disp(python + mp.ipcore_codegen_path + filesep + "create_hw_tcl.py -c " + config_file + " -w " + hdlpath + " -o " + outfile )
-system(python + mp.ipcore_codegen_path + filesep + "create_hw_tcl.py -c " + config_file + " -w " + hdlpath + " -o " + outfile );
-=======
 
 hw_tcl_cmd = python + mp.codegen_path + filesep + "autogen_hw_tcl.py -c " + config_file + " -w " + hdlpath + " -o " + outfile + " -s " + sourcePatternsStr;
->>>>>>> Initial code to support model references
 
 disp(hw_tcl_cmd)
 system(hw_tcl_cmd);
 
-<<<<<<< HEAD
-=======
->>>>>>> Stashed changes
->>>>>>> Initial code to support model references
 disp(['      created tcl file: ' outfile])
 
 disp('vgen: Executing Quartus workflow')

--- a/vgen_process_simulink_model.m
+++ b/vgen_process_simulink_model.m
@@ -18,9 +18,34 @@
 % openspeech@flatearthinc.com
 
 %% Generate the Simulink model VHDL code
-
+mp.generation_active = 1;
 % run the hdl coder
-generate_vhdl;
+%try
+    generate_vhdl;
+%catch
+%    mp.generation_active = 0;
+%    return;
+%end;
+mp.generation_active = 0;
+
+mdlrefs = find_mdlrefs(mp.modelName);
+prefix = hdlget_param(mp.modelName, 'ModulePrefix');
+sourcePatterns = [".*_pkg\.vhd"];
+
+for n = 1:numel(mdlrefs)
+    mdlref = string(mdlrefs{n});
+    if mdlref == mp.modelName
+        sourcePatterns(end + 1) = prefix + "(?!avalon).*\.vhd";
+    else
+        sourcePatterns(end + 1) = mdlref + filesep + filesep + prefix + ".*\.vhd";
+    end
+end
+
+sourcePatternsStr = "";
+for pattern = sourcePatterns
+    sourcePatternsStr =  sourcePatternsStr + " " + string('"') + pattern + '"'; 
+end
+
 
 % this is where hdlworkflow puts the vhdl files
 hdlpath = [mp.modelPath filesep 'hdlsrc' filesep mp.modelAbbreviation];
@@ -53,12 +78,26 @@ disp(['      created vhdl file: ' outfile])
 disp('vgen: Creating .tcl script for Platform Designer.')
 % NOTE: platform designer only adds components if they have the _hw.tcl suffix
 outfile = [hdlpath filesep mp.modelName '_dataplane_avalon_hw.tcl'];
+<<<<<<< HEAD
 
 hw_tcl_cmd = python + mp.codegen_path + filesep + "autogen_hw_tcl.py -c " + config_file + " -w " + hdlpath + " -o " + outfile;
+=======
+<<<<<<< Updated upstream
+disp(['file ' config_filepath ' out ' outfile ' path ' hdlpath])
+disp(python + mp.ipcore_codegen_path + filesep + "create_hw_tcl.py -c " + config_file + " -w " + hdlpath + " -o " + outfile )
+system(python + mp.ipcore_codegen_path + filesep + "create_hw_tcl.py -c " + config_file + " -w " + hdlpath + " -o " + outfile );
+=======
+
+hw_tcl_cmd = python + mp.codegen_path + filesep + "autogen_hw_tcl.py -c " + config_file + " -w " + hdlpath + " -o " + outfile + " -s " + sourcePatternsStr;
+>>>>>>> Initial code to support model references
 
 disp(hw_tcl_cmd)
 system(hw_tcl_cmd);
 
+<<<<<<< HEAD
+=======
+>>>>>>> Stashed changes
+>>>>>>> Initial code to support model references
 disp(['      created tcl file: ' outfile])
 
 disp('vgen: Executing Quartus workflow')


### PR DESCRIPTION
This adds support for adding all vhdl files generated via model references to also be added to the _hw.tcl file for use by Quartus during compilation. It achieves this through updating `populate_additional_filesets` in `ipcore/dataplane_config.py` to use regex patterns to find source files. These regex patterns are created in `vgen_process_simulink_model.m` and are passed in via the call to `autogen_hw_tcl.py`.