### PR TITLE
24.23 support on AM, updated driver name, etc

### DIFF
--- a/device_drivers/device.py
+++ b/device_drivers/device.py
@@ -192,7 +192,7 @@ class Device:
         c_code += "static int " + self.name + "_probe(struct platform_device *pdev) {\n"
         c_code += "  int ret_val = -EBUSY;\n"
         c_code += ("  char device_name[" + str(len(self.name) + 12) +"] = \"fe_" + self.name
-                        + "_\";\n")  # adding 12 to len is arbitrary
+                        + "\";\n")  # adding 12 to len is arbitrary
         c_code += "  char deviceMinor[20];\n"
         c_code += "  int status;\n"
         c_code += "  struct device *device_obj;\n"
@@ -212,9 +212,6 @@ class Device:
         c_code += "  status = alloc_chrdev_region(&dev_num, 0, 1, \"fe_" + self.name + "_\");\n"
         c_code += "  if (status != 0)\n"
         c_code += "    goto bad_alloc_chrdev_region;\n"
-        c_code += "  sprintf(deviceMinor, \"%d\", MAJOR(dev_num));\n"
-        c_code += "  strcat(device_name, deviceMinor);\n"
-        c_code += "  pr_info(\"%s\\n\", device_name);\n"
         c_code += "  cl = class_create(THIS_MODULE, device_name);\n"
         c_code += "  if (cl == NULL)\n"
         c_code += "    goto bad_class_create;\n"
@@ -222,6 +219,9 @@ class Device:
         c_code += "  status = cdev_add(&" + devp_struct_name + "->cdev, dev_num, 1);\n"
         c_code += "  if (status != 0)\n"
         c_code += "    goto bad_cdev_add;\n"
+        c_code += "  sprintf(deviceMinor, \"%d\", MINOR(dev_num));\n"
+        c_code += "  strcat(device_name, deviceMinor);\n"
+        c_code += "  pr_info(\"%s\\n\", device_name);\n"
         c_code += f" device_obj = device_create_with_groups(cl, NULL, dev_num, NULL, {self.name}_groups, device_name);\n"
         c_code += f"  if (device_obj == NULL)\n"
         c_code += "    goto bad_device_create;\n"

--- a/device_drivers/device.py
+++ b/device_drivers/device.py
@@ -35,7 +35,6 @@ def get_device(device_type, config):
         # DeviceType.I2C: I2CDevice(config.device_name, config.compatible, config.device_address), 
         DeviceType.FPGA: FPGADevice(config.device_name, config.compatible) 
     }
-
     device = device_map.get(device_type, Device(config.device_name, config.compatible))
     device.device_attributes = config.device_attributes
     return device
@@ -194,7 +193,7 @@ class Device:
         c_code = ""
         c_code += f"static int {self.name}_probe(struct platform_device *pdev) {{\n"
         c_code += "  int ret_val = -EBUSY;\n"
-        c_code += (f"  char device_name[" + str(len(self.name) + 12) +"] = \"{DRIVER_PREFIX}_" + self.name
+        c_code += (f"  char device_name[{str(len(self.name) + 12)}] = \"{DRIVER_PREFIX}_" + self.name
                         + "\";\n")  # adding 12 to len is arbitrary
         c_code += "  char deviceMinor[20];\n"
         c_code += "  int status;\n"

--- a/device_drivers/device.py
+++ b/device_drivers/device.py
@@ -23,6 +23,9 @@
 from enum import Enum
 
 from time import strftime
+
+DRIVER_PREFIX = "al"
+
 # Refactor constants into C constants/defines such as
     # i2c/ spi address
     # nominal states ex. 0x35 is the initialization data
@@ -56,7 +59,7 @@ class Device:
         c_code += "static dev_t dev_num;"
         c_code += self._create_dev_struct()
         c_code += self._create_func_prototypes()
-        c_code += "typedef struct fe_" + self.name + "_dev fe_" + self.name + "_dev_t;\n"
+        c_code += f"typedef struct {DRIVER_PREFIX}_{self.name}_dev {DRIVER_PREFIX}_{self.name}_dev_t;\n"
         c_code += self._create_id_matching_struct()
         c_code += self._create_platform_driver_struct()
         c_code += self._create_file_ops_struct()
@@ -79,14 +82,14 @@ class Device:
         return c_code
     def _create_func_prototypes(self): 
         c_code = ""
-        c_code += "static int " + self.name + "_init(void);\n"
-        c_code += "static void " + self.name + "_exit(void);\n"
-        c_code += "static int " + self.name + "_probe(struct platform_device *pdev);\n"
-        c_code += "static int " + self.name + "_remove(struct platform_device *pdev);\n"
-        c_code += "static ssize_t " + self.name + "_read(struct file *file, char *buffer, size_t len, loff_t *offset);\n"
-        c_code += "static ssize_t " + self.name + "_write(struct file *file, const char *buffer, size_t len, loff_t *offset);\n"
-        c_code += "static int " + self.name + "_open(struct inode *inode, struct file *file);\n"
-        c_code += "static int " + self.name + "_release(struct inode *inode, struct file *file);\n\n"
+        c_code += f"static int {self.name}_init(void);\n"
+        c_code += f"static void {self.name}_exit(void);\n"
+        c_code += f"static int {self.name}_probe(struct platform_device *pdev);\n"
+        c_code += f"static int {self.name}_remove(struct platform_device *pdev);\n"
+        c_code += f"static ssize_t {self.name}_read(struct file *file, char *buffer, size_t len, loff_t *offset);\n"
+        c_code += f"static ssize_t {self.name}_write(struct file *file, const char *buffer, size_t len, loff_t *offset);\n"
+        c_code += f"static int {self.name}_open(struct inode *inode, struct file *file);\n"
+        c_code += f"static int {self.name}_release(struct inode *inode, struct file *file);\n\n"
         for attr in self.device_attributes:
             c_code += attr.create_func_prototypes()
         return c_code
@@ -106,40 +109,40 @@ class Device:
     def _create_module_declarations(self):
         c_code = "\nMODULE_LICENSE(\"GPL\");\n"
         c_code += "MODULE_AUTHOR(\"Autogen <support@flatearthinc.com\");\n"
-        c_code += "MODULE_DESCRIPTION(\"Loadable kernel module for the " + self.name + "\");\n"
+        c_code += f"MODULE_DESCRIPTION(\"Loadable kernel module for the {self.name}\");\n"
         c_code += "MODULE_VERSION(\"1.0\");\n"
-        c_code += "MODULE_DEVICE_TABLE(of, fe_" + self.name + "_dt_ids);\n"
+        c_code += f"MODULE_DEVICE_TABLE(of, {DRIVER_PREFIX}_{self.name}_dt_ids);\n"
     
-        c_code += "module_init(" + self.name + "_init);\n"
-        c_code += "module_exit(" + self.name + "_exit);\n\n"
+        c_code += f"module_init({self.name}_init);\n"
+        c_code += f"module_exit({self.name}_exit);\n\n"
         return c_code
     def _create_file_ops_struct(self):
         c_code = "/* File ops struct */\n"
-        c_code += "static const struct file_operations fe_" + self.name + "_fops = {\n"
+        c_code += f"static const struct file_operations {DRIVER_PREFIX}_{self.name}_fops = {{\n"
         c_code += "  .owner = THIS_MODULE,\n"
-        c_code += "  .read = "    + self.name + "_read,\n"
-        c_code += "  .write = "   + self.name + "_write,\n"
-        c_code += "  .open = "    + self.name + "_open,\n"
-        c_code += "  .release = " + self.name + "_release,\n"
+        c_code += f"  .read = {self.name}_read,\n"
+        c_code += f"  .write = {self.name}_write,\n"
+        c_code += f"  .open = {self.name}_open,\n"
+        c_code += f"  .release = {self.name}_release,\n"
         c_code += "};\n\n"
         return c_code
 
     def _create_platform_driver_struct(self):
         c_code = "/* Platform driver struct */\n"
-        c_code += "static struct platform_driver " + self.name + "_platform = {\n"
-        c_code += "  .probe = " + self.name + "_probe,\n"
-        c_code += "  .remove = " + self.name + "_remove,\n"
+        c_code += f"static struct platform_driver {self.name}_platform = {{\n"
+        c_code += f"  .probe = {self.name}_probe,\n"
+        c_code += f"  .remove = {self.name}_remove,\n"
         c_code += "  .driver = {\n"
-        c_code += "    .name = \"Flat Earth " + self.name + " Driver\",\n"
+        c_code += f"    .name = \"Flat Earth {self.name} Driver\",\n"
         c_code += "    .owner = THIS_MODULE,\n"
-        c_code += "    .of_match_table = fe_" + self.name + "_dt_ids\n"
+        c_code += f"    .of_match_table = {DRIVER_PREFIX}_{self.name}_dt_ids\n"
         c_code += "  }\n"
         c_code += "};\n\n"
         return c_code
 
     def _create_id_matching_struct(self):
         c_code = "/* ID Matching struct */\n"
-        c_code += "static struct of_device_id fe_" + self.name + "_dt_ids[] = {\n"
+        c_code += f"static struct of_device_id {DRIVER_PREFIX}_{self.name}_dt_ids[] = {{\n"
         c_code += "  {\n"
         c_code += "    .compatible = \"" + self.compatible + "\"\n"
         c_code += "  },\n"
@@ -149,7 +152,7 @@ class Device:
 
     def _create_dev_struct(self):
         c_code = "\n/* Device struct */\n"
-        c_code += "struct fe_" + self.name + "_dev {\n"
+        c_code += f"struct {DRIVER_PREFIX}_{self.name}_dev {{\n"
         c_code += "  struct cdev cdev;\n"
         c_code += "  void __iomem *regs;\n"
         for attr in self.device_attributes:
@@ -173,15 +176,15 @@ class Device:
         c_code += "  int ret_val = 0;\n"
         time_string = strftime("%Y-%m-%d %H:%M")
         c_code += "  printk(KERN_ALERT \"FUNCTION AUTO GENERATED AT: " + time_string + "\\n\");\n"
-        c_code += "  pr_info(\"Initializing the Flat Earth " + self.name + " module\\n\");\n"
+        c_code += f"  pr_info(\"Initializing the Flat Earth {self.name} module\\n\");\n"
         c_code += "  // Register our driver with the \"Platform Driver\" bus\n"
-        c_code += "  ret_val = platform_driver_register(&" + self.name + "_platform);"
+        c_code += f"  ret_val = platform_driver_register(&{self.name}_platform);"
         c_code += "  if (ret_val != 0) {\n"
         c_code += "    pr_err(\"platform_driver_register returned %d\\n\", ret_val);\n"
         c_code += "    return ret_val;\n"
         c_code += "  }\n"
         c_code += self._init_device()
-        c_code += "  pr_info(\"Flat Earth " + self.name + " module successfully initialized!\\n\");\n"
+        c_code += f"  pr_info(\"Flat Earth {self.name} module successfully initialized!\\n\");\n"
         c_code += "  return 0;\n"
         c_code += "}\n"
         return c_code
@@ -189,18 +192,18 @@ class Device:
         return ""
     def _create_probe_func(self):
         c_code = ""
-        c_code += "static int " + self.name + "_probe(struct platform_device *pdev) {\n"
+        c_code += f"static int {self.name}_probe(struct platform_device *pdev) {{\n"
         c_code += "  int ret_val = -EBUSY;\n"
-        c_code += ("  char device_name[" + str(len(self.name) + 12) +"] = \"fe_" + self.name
+        c_code += (f"  char device_name[" + str(len(self.name) + 12) +"] = \"{DRIVER_PREFIX}_" + self.name
                         + "\";\n")  # adding 12 to len is arbitrary
         c_code += "  char deviceMinor[20];\n"
         c_code += "  int status;\n"
         c_code += "  struct device *device_obj;\n"
-        devp_struct_name = "fe_" + self.name + "_devp"
-        c_code += "  fe_" + self.name + "_dev_t * " + devp_struct_name + ";\n"
+        devp_struct_name = f"{DRIVER_PREFIX}_{self.name}_devp"
+        c_code += f"  {DRIVER_PREFIX}_{self.name}_dev_t * " + devp_struct_name + ";\n"
         c_code += "  struct resource *r = NULL;\n"
-        c_code += "  pr_info(\"" + self.name + "_probe enter\\n\");\n"
-        c_code += ("  " + devp_struct_name + " = devm_kzalloc(&pdev->dev, sizeof(fe_" + self.name +
+        c_code += f"  pr_info(\"{self.name}_probe enter\\n\");\n"
+        c_code += (f"  {devp_struct_name} = devm_kzalloc(&pdev->dev, sizeof({DRIVER_PREFIX}_" + self.name +
                         "_dev_t), GFP_KERNEL);\n")
         c_code += self._init_platform()
         c_code += "  platform_set_drvdata(pdev, (void *)" + devp_struct_name + ");\n"
@@ -209,13 +212,13 @@ class Device:
         c_code += "    goto bad_mem_alloc;\n"
         c_code += "  strcpy(" + devp_struct_name + "->name, (char *)pdev->name);\n"
         c_code += "  pr_info(\"%s\\n\", (char *)pdev->name);\n"
-        c_code += "  status = alloc_chrdev_region(&dev_num, 0, 1, \"fe_" + self.name + "_\");\n"
+        c_code += f"  status = alloc_chrdev_region(&dev_num, 0, 1, \"{DRIVER_PREFIX}_{self.name}_\");\n"
         c_code += "  if (status != 0)\n"
         c_code += "    goto bad_alloc_chrdev_region;\n"
         c_code += "  cl = class_create(THIS_MODULE, device_name);\n"
         c_code += "  if (cl == NULL)\n"
         c_code += "    goto bad_class_create;\n"
-        c_code += "  cdev_init(&" + devp_struct_name + "->cdev, &fe_" + self.name + "_fops);\n"
+        c_code += f"  cdev_init(&{devp_struct_name}->cdev, &{DRIVER_PREFIX}_{self.name}_fops);\n"
         c_code += "  status = cdev_add(&" + devp_struct_name + "->cdev, dev_num, 1);\n"
         c_code += "  if (status != 0)\n"
         c_code += "    goto bad_cdev_add;\n"
@@ -226,37 +229,37 @@ class Device:
         c_code += f"  if (device_obj == NULL)\n"
         c_code += "    goto bad_device_create;\n"
         c_code += "  dev_set_drvdata(device_obj, " + devp_struct_name + ");\n"
-        c_code += "  pr_info(\"" + self.name + " exit\\n\");\n"
+        c_code += f"  pr_info(\"{self.name} exit\\n\");\n"
         c_code += "  return 0;\n"
         c_code += "bad_device_create:\n"
         c_code += "bad_cdev_add:\n"
-        c_code += "  cdev_del(&fe_" + self.name + "_devp->cdev);\n"
+        c_code += f"  cdev_del(&{DRIVER_PREFIX}_{self.name}_devp->cdev);\n"
         c_code += "bad_class_create:\n"
         c_code += "  class_destroy(cl);\n"
         c_code += "bad_alloc_chrdev_region:\n"
         c_code += "  unregister_chrdev_region(dev_num, 1);\n"
         c_code += "bad_mem_alloc:\n"
         c_code += "bad_exit_return:\n"
-        c_code += "  pr_info(\"" + self.name + "_probe bad exit\\n\");\n"
+        c_code += f"  pr_info(\"{self.name}_probe bad exit\\n\");\n"
         c_code += "  return ret_val;\n"
         c_code += "}\n\n\n"
         return c_code
     def _init_platform(self):
         return ""
     def _create_file_ops_funcs(self):
-        c_code = "static int " + self.name + "_open(struct inode *inode, struct file *file) {\n"
+        c_code = f"static int {self.name}_open(struct inode *inode, struct file *file) {{\n"
         c_code += "  // TODO: fill this in (if its needed, it might not be)\n"
         c_code += "  return 0;\n"
         c_code += "}\n\n"
-        c_code += "static int " + self.name + "_release(struct inode *inode, struct file *file) {\n"
+        c_code += f"static int {self.name}_release(struct inode *inode, struct file *file) {{\n"
         c_code += "  // TODO: fill this in (if its needed, it might not be)\n"
         c_code += "  return 0;\n"
         c_code += "}\n\n"
-        c_code += "static ssize_t " + self.name + "_read(struct file *file, char *buffer, size_t len, loff_t *offset) {\n"
+        c_code += f"static ssize_t {self.name}_read(struct file *file, char *buffer, size_t len, loff_t *offset) {{\n"
         c_code += "  // TODO: fill this in (if its needed, it might not be)\n"
         c_code += "  return 0;\n"
         c_code += "}\n\n"
-        c_code += "static ssize_t " + self.name + "_write(struct file *file, const char *buffer, size_t len, loff_t *offset) {\n"
+        c_code += f"static ssize_t {self.name}_write(struct file *file, const char *buffer, size_t len, loff_t *offset) {{\n"
         c_code += "  // TODO: fill this in (if its needed, it might not be)\n"
         c_code += "  return 0;\n"
         c_code += "}\n"
@@ -264,25 +267,25 @@ class Device:
     
     def _create_remove_func(self):
         c_code = ""
-        c_code += "static int " + self.name + "_remove(struct platform_device *pdev) {\n"
-        c_code += "  fe_" + self.name + "_dev_t *dev = (fe_" + self.name + "_dev_t *)platform_get_drvdata(pdev);\n"
-        c_code += "  pr_info(\"" + self.name + "_remove enter\\n\");\n"
+        c_code += f"static int {self.name}_remove(struct platform_device *pdev) {{\n"
+        c_code += f"  {DRIVER_PREFIX}_{self.name}_dev_t *dev = ({DRIVER_PREFIX}_{self.name}_dev_t *)platform_get_drvdata(pdev);\n"
+        c_code += f"  pr_info(\"{self.name}_remove enter\\n\");\n"
         c_code += "  device_destroy(cl, dev_num);\n"
         c_code += "  cdev_del(&dev->cdev);\n"
         c_code += "  class_destroy(cl);\n"
         c_code += "  unregister_chrdev_region(dev_num, 2);\n"
-        c_code += "  pr_info(\"" + self.name + "_remove exit\\n\");\n"
+        c_code += f"  pr_info(\"{self.name}_remove exit\\n\");\n"
         c_code += "  return 0;\n"
         c_code += "}\n\n\n"
         return c_code
 
     def _create_exit_func(self):
-        c_code = "static void " + self.name + "_exit(void) {\n"
-        c_code += "  pr_info(\"Flat Earth " + self.name + " module exit\\n\");\n"
-        c_code += "  platform_driver_unregister(&" + self.name + "_platform);\n"
+        c_code = f"static void {self.name}_exit(void) {{\n"
+        c_code += f"  pr_info(\"Flat Earth {self.name} module exit\\n\");\n"
+        c_code += f"  platform_driver_unregister(&{self.name}_platform);\n"
         c_code += self._exit_device()
             
-        c_code += "  pr_info(\"Flat Earth " + self.name + " module successfully unregistered\\n\");\n"
+        c_code += f"  pr_info(\"Flat Earth {self.name} module successfully unregistered\\n\");\n"
         c_code += "}\n"
         return c_code
     def _exit_device(self):
@@ -292,7 +295,7 @@ class FPGADevice(Device):
     def __init__(self, name, compatible):
         super().__init__(name, compatible)
     def _init_platform(self):
-        devp_struct_name = "fe_" + self.name + "_devp"
+        devp_struct_name = f"{DRIVER_PREFIX}_{self.name}_devp"
         c_code = ""
         c_code += "  r = platform_get_resource(pdev, IORESOURCE_MEM, 0);\n"
         c_code += "  if (r == NULL) {\n"
@@ -301,7 +304,7 @@ class FPGADevice(Device):
         c_code += "  }\n"
         c_code += "  " + devp_struct_name + "->regs = devm_ioremap_resource(&pdev->dev, r);\n"
         c_code += "  if (IS_ERR(" + devp_struct_name + "->regs)) {\n"
-        c_code += "    ret_val = PTR_ERR(fe_" + self.name + "_devp->regs);\n"
+        c_code += f"    ret_val = PTR_ERR({DRIVER_PREFIX}_{self.name}_devp->regs);\n"
         c_code += "    goto bad_exit_return;\n  }\n"
         return c_code
 
@@ -327,7 +330,7 @@ class SPIDevice(Device):
         c_code = ""
         c_code += "  // Register the device\n"
         c_code += "  struct spi_board_info spi_device_info = {\n"
-        c_code += "    .modalias = \"fe_" + self.name + "_\",\n"
+        c_code += f"    .modalias = \"{DRIVER_PREFIX}_{self.name}_\",\n"
         c_code += "    .max_speed_hz = " + self.speed + ",\n"
         c_code += "    .bus_num = 0,\n"
         c_code += "    .chip_select = " + self.chip_select + ",\n"
@@ -420,29 +423,29 @@ class I2CDevice(Device):
         return c_code
     def _create_i2c_structs(self):
         c_code = ""
-        c_code += "struct i2c_client * " + self.name + "_i2c_client;\n"
-        c_code += "static struct i2c_device_id " + self.name + "_id[] = {\n"
+        c_code += f"struct i2c_client * {self.name}_i2c_client;\n"
+        c_code += f"static struct i2c_device_id {self.name}_id[] = {{\n"
         c_code += "  {\n"
-        c_code += "    \"" + self.name + "_i2c\"," + self.address + "\n"
+        c_code += f"    \"{self.name}_i2c\"," + self.address + "\n"
         c_code += "  },\n"
         c_code += "  { }\n"
         c_code += "};\n\n"
-        c_code += "static struct i2c_board_info " + self.name + "_i2c_info = {\n"
-        c_code += "  I2C_BOARD_INFO(\"" + self.name + "_i2c\"," + self.address + "),\n"
+        c_code += f"static struct i2c_board_info {self.name}_i2c_info = {{\n"
+        c_code += f"  I2C_BOARD_INFO(\"{self.name}_i2c\"," + self.address + "),\n"
         c_code += "};\n\n"
-        c_code += "static int " + self.name + "_i2c_probe(struct i2c_client *client, const struct i2c_device_id *id) {\n"
+        c_code += f"static int {self.name}_i2c_probe(struct i2c_client *client, const struct i2c_device_id *id) {{\n"
         c_code += "  return 0;\n"
         c_code += "}\n"
-        c_code += "static int " + self.name + "_i2c_remove(struct i2c_client *client) {\n"
+        c_code += f"static int {self.name}_i2c_remove(struct i2c_client *client) {{\n"
         c_code += "  return 0;\n"
         c_code += "}\n"
-        c_code += "struct i2c_driver " + self.name + "_i2c_driver = {\n"
+        c_code += f"struct i2c_driver {self.name}_i2c_driver = {{\n"
         c_code += "  .driver = {\n"
-        c_code += "    .name=\"" + self.name + "_i2c\",\n"
+        c_code += f"    .name=\"{self.name}_i2c\",\n"
         c_code += "  },\n"
-        c_code += "  .probe = " + self.name + "_i2c_probe,\n"
-        c_code += "  .remove = " + self.name + "_i2c_remove,\n"
-        c_code += "  .id_table = " + self.name + "_id,\n"
+        c_code += f"  .probe = {self.name}_i2c_probe,\n"
+        c_code += f"  .remove = {self.name}_i2c_remove,\n"
+        c_code += f"  .id_table = {self.name}_id,\n"
         c_code += "};\n"
         return c_code
     def _init_device(self):
@@ -451,17 +454,17 @@ class I2CDevice(Device):
         c_code += "     I2C communication\n"
         c_code += "  --------------------------------------------------------*/\n"
         c_code += "  // Register the device\n"
-        c_code += "  ret_val = i2c_add_driver(&" + self.name + "_i2c_driver);\n"
+        c_code += f"  ret_val = i2c_add_driver(&{self.name}_i2c_driver);\n"
         c_code += "  if (ret_val < 0) {\n"
         c_code += "    pr_err(\"Failed to register I2C driver\");\n"
         c_code += "    return ret_val;\n"
         c_code += "  }\n"
         c_code += "  i2c_adapt = i2c_get_adapter(0);\n"
         c_code += "  memset(&i2c_info,0,sizeof(struct i2c_board_info));\n"
-        c_code += "  strlcpy(i2c_info.type, \"" + self.name + "_i2c\",I2C_NAME_SIZE);\n"
-        c_code += "  " + self.name + "_i2c_client = i2c_new_device(i2c_adapt,&" + self.name + "_i2c_info);\n"
+        c_code += f"  strlcpy(i2c_info.type, \"{self.name}_i2c\",I2C_NAME_SIZE);\n"
+        c_code += f"  {self.name}_i2c_client = i2c_new_device(i2c_adapt,&{self.name}_i2c_info);\n"
         c_code += "  i2c_put_adapter(i2c_adapt);\n"
-        c_code += "  if (!" + self.name + "_i2c_client) {\n"
+        c_code += f"  if (!{self.name}_i2c_client) {{\n"
         c_code += "    pr_err(\"Failed to connect to I2C client\\n\");\n"
         c_code += "    ret_val = -ENODEV;\n"
         c_code += "    return ret_val;\n"

--- a/device_drivers/device_attributes.py
+++ b/device_drivers/device_attributes.py
@@ -20,7 +20,7 @@
 #     Bozeman, MT 59718
 #     openspeech@flatearthinc.com
 
-from device_drivers.device import DeviceType
+from device_drivers.device import DeviceType, DRIVER_PREFIX
 
 class DataType:
     """Represent a fixed point number."""
@@ -137,7 +137,7 @@ class DeviceAttribute:
             Returns C function definition for reading the attribute value
         """
         c_code = "static ssize_t " + self.name + "_read(struct device *dev, struct device_attribute *attr, char *buf) {\n"
-        c_code += "  fe_" + device_name + "_dev_t * devp = (fe_" + device_name + "_dev_t *)dev_get_drvdata(dev);\n"
+        c_code += f"  {DRIVER_PREFIX}_{device_name}_dev_t * devp = ({DRIVER_PREFIX}_{device_name}_dev_t *)dev_get_drvdata(dev);\n"
         if self.data_type.name == "string":
             c_code += self._read_string()
         else:
@@ -244,7 +244,7 @@ class FPGADeviceAttribute(DeviceAttribute):
         c_code += "  char substring[80];\n"
         c_code += "  int substring_count = 0;\n"
         c_code += "  int i;\n"
-        c_code += "  fe_" + device_name + "_dev_t *devp = (fe_" + device_name + \
+        c_code += f"  {DRIVER_PREFIX}_{device_name}_dev_t *devp = ({DRIVER_PREFIX}_" + device_name + \
                         "_dev_t *)dev_get_drvdata(dev);\n"
         c_code += "  for (i = 0; i < count; i++) {\n"
         c_code += "    if ((buf[i] != ',') && (buf[i] != ' ') && (buf[i] != '\\0') && (buf[i] != '\\r') && (buf[i] != '\\n')) {\n"
@@ -329,7 +329,7 @@ class SPIDeviceAttribute(DeviceAttribute):
                 c_code += ","
         c_code += "};\n"
         c_code += "  uint8_t code = 0x00;\n"
-        c_code += "  fe_" + device_name + "_dev_t * devp = (fe_" + device_name + \
+        c_code += f"  {DRIVER_PREFIX}_{device_name}_dev_t * devp = ({DRIVER_PREFIX}_" + device_name + \
                         "_dev_t *) dev_get_drvdata(dev);\n"
         c_code += "  for (i = 0; i < count; i++) {\n"
         c_code += "    if ((buf[i] != ',') && (buf[i] != ' ') && (buf[i] != '\\0') && (buf[i] != '\\r') && (buf[i] != '\\n')) {\n"
@@ -399,7 +399,7 @@ class I2CDeviceAttribute(DeviceAttribute):
                 c_code += ","
         c_code += "};\n"
         c_code += "  uint8_t code = 0x00;\n"
-        c_code += "  fe_" + device_name + "_dev_t * devp = (fe_" + device_name + \
+        c_code += f"  {DRIVER_PREFIX}_{device_name}_dev_t * devp = ({DRIVER_PREFIX}_" + device_name + \
                         "_dev_t *) dev_get_drvdata(dev);\n"
         c_code += "  for (i = 0; i < count; i++) {\n"
         c_code += "    if ((buf[i] != ',') && (buf[i] != ' ') && (buf[i] != '\\0') && (buf[i] != '\\r') && (buf[i] != '\\n')) {\n"

--- a/ipcore/avalon_config.py
+++ b/ipcore/avalon_config.py
@@ -61,6 +61,7 @@ class AvalonConfig:
         json_registers = modeljson['devices'][0]["registers"]
         registers = []
         for reg in json_registers:
+            direction = reg.get("direction") or "in"
             registers.append(Register(
                 reg["name"],
                 DataType(
@@ -68,7 +69,8 @@ class AvalonConfig:
                     reg["dataType"]["fractionLength"],
                     reg["dataType"]["signed"]
                     ),
-                reg["defaultValue"]
+                reg["defaultValue"],
+                direction
             ))
         entity_name = modeljson['devices'][0]["name"] + "_dataplane"
         is_sample_based = modeljson['system']['processing'].lower() == "sample"

--- a/ipcore/avalon_wrapper.py
+++ b/ipcore/avalon_wrapper.py
@@ -276,8 +276,10 @@ def create_bus_read_logic(register_signals, avalon_slave_readdata_signal):
     logic_string += tab() + \
         f"if rising_edge(clk) and {read_enable} = '1' then \n"
     logic_string += tab(2) + f"case {avalon_slave_address} is\n"
-
-    addr_width = int(ceil(log(len(register_signals), 2)))
+    try:
+        addr_width = int(ceil(log(len(register_signals), 2)))
+    except ValueError:
+        addr_width = 0
     for idx, reg in enumerate(register_signals):
         addr = "{0:0{1}b}".format(idx, addr_width)
         assignment = data_out.generate_assignment(reg)
@@ -322,7 +324,10 @@ def create_bus_write_logic(register_ports, avalon_slave_writedata_signal):
         f"elsif rising_edge(clk) and {write_enable} = '1' then\n"
     logic_string += tab(2) + f"case {avalon_slave_address} is\n"
 
-    addr_width = int(ceil(log(len(register_ports), 2)))
+    try:
+        addr_width = int(ceil(log(len(register_ports), 2)))
+    except ValueError:
+        addr_width = 0
     for idx, reg in enumerate(register_ports):
         # if(reg.direction == PortDir.Out):
         #     continue

--- a/ipcore/dataplane_config.py
+++ b/ipcore/dataplane_config.py
@@ -55,7 +55,7 @@ class DataplaneConfig:
         if len(model.devices[deviceIndex].registers) > 0:
             config.has_avalon_mm_slave_signal = True
             config.address_bus_size = int(
-                ceil(log(len(model.devices[deviceIndex].registers))))
+                ceil(log(len(model.devices[deviceIndex].registers), 2)))
 
         config.sink_max_channel = model.system.audioIn.numberOfChannels - 1
         config.source_max_channel = model.system.audioOut.numberOfChannels - 1

--- a/ipcore/dataplane_config.py
+++ b/ipcore/dataplane_config.py
@@ -21,6 +21,8 @@ class DataplaneConfig:
 
         self.sink_max_channel = 0
         self.source_max_channel = 0
+        self.sink_bits_per_symbol = 24
+        self.source_bits_per_symbol = 24
 
     def populate_additional_filesets(self, additionalFilesetAbsDir, sourceFilePatterns):
         for pattern in sourceFilePatterns:
@@ -57,6 +59,8 @@ class DataplaneConfig:
 
         config.sink_max_channel = model.system.audioIn.numberOfChannels - 1
         config.source_max_channel = model.system.audioOut.numberOfChannels - 1
+        config.sink_bits_per_symbol = model.system.audioIn.wordLength
+        config.source_bits_per_symbol = model.system.audioOut.wordLength
         return config
 
 

--- a/ipcore/hw_tcl_generator.py
+++ b/ipcore/hw_tcl_generator.py
@@ -131,8 +131,9 @@ class HwTCLGenerator:
 
 
     def create_mm_connection_point(self):
-        if not self.has_avalon_mm_slave_signal:
-            return ""
+        # Even if no memory, the interface is still needed
+        #if not self.has_avalon_mm_slave_signal:
+        #    return ""
         tcl = ""
         memory_slave = 'avalon_slave'
         tcl += "add_interface " + memory_slave + " avalon end\n"

--- a/ipcore/hw_tcl_generator.py
+++ b/ipcore/hw_tcl_generator.py
@@ -20,6 +20,9 @@ class HwTCLGenerator:
         self.sink_max_channel = dataplane_config.sink_max_channel
         self.source_max_channel = dataplane_config.source_max_channel
 
+        self.sink_bits_per_symbol = dataplane_config.sink_bits_per_symbol
+        self.source_bits_per_symbol = dataplane_config.source_bits_per_symbol
+
     def write_tcl(self, outputFilename):
         with open(outputFilename, "w") as out_file:
             out_file.write(self.generate())
@@ -189,7 +192,7 @@ class HwTCLGenerator:
         tcl += "set_interface_property " + sink + " associatedClock clock\n"
         tcl += "set_interface_property " + sink + " associatedReset reset\n"
         tcl += "set_interface_property " + sink + \
-            " dataBitsPerSymbol " + str(self.data_bus_size) + "\n"
+            " dataBitsPerSymbol " + str(self.sink_bits_per_symbol) + "\n"
         tcl += "set_interface_property " + sink + " errorDescriptor \"\"\n"
         tcl += "set_interface_property " + \
             sink + " firstSymbolInHighOrderBits true\n"
@@ -203,7 +206,7 @@ class HwTCLGenerator:
             sink + " CMSIS_SVD_VARIABLES \"\"\n"
         tcl += "set_interface_property " + sink + " SVD_ADDRESS_GROUP \"\"\n"
         tcl += "add_interface_port " + sink + " avalon_sink_valid valid Input 1\n"
-        tcl += "add_interface_port " + sink + " avalon_sink_data data Input 32\n"
+        tcl += f"add_interface_port {sink} avalon_sink_data data Input {self.sink_bits_per_symbol}\n"
         tcl += f"add_interface_port {sink} avalon_sink_channel channel Input {int(ceil(log(self.sink_max_channel + 1, 2))) or 1}\n"
         tcl += "add_interface_port " + sink + " avalon_sink_error error Input 2\n"
         tcl += "\n\n\n"
@@ -217,7 +220,7 @@ class HwTCLGenerator:
         tcl += "set_interface_property " + source + " associatedClock clock\n"
         tcl += "set_interface_property " + source + " associatedReset reset\n"
         tcl += "set_interface_property " + source + \
-            " dataBitsPerSymbol " + str(self.data_bus_size) + "\n"
+            " dataBitsPerSymbol " + str(self.source_bits_per_symbol) + "\n"
         tcl += "set_interface_property " + source + " errorDescriptor \"\"\n"
         tcl += "set_interface_property " + \
             source + " firstSymbolInHighOrderBits true\n"
@@ -232,7 +235,7 @@ class HwTCLGenerator:
         tcl += "set_interface_property " + source + " SVD_ADDRESS_GROUP \"\"\n"
 
         tcl += "add_interface_port " + source + " avalon_source_valid valid Output 1\n"
-        tcl += "add_interface_port " + source + " avalon_source_data data Output 32\n"
+        tcl += f"add_interface_port {source} avalon_source_data data Output {self.source_bits_per_symbol}\n"
         tcl += f"add_interface_port {source} avalon_source_channel channel Output {int(ceil(log(self.source_max_channel + 1, 2))) or 1}\n"
         tcl += "add_interface_port " + source + " avalon_source_error error Output 2\n"
         tcl += "\n\n\n"

--- a/ipcore/util.py
+++ b/ipcore/util.py
@@ -1,7 +1,7 @@
 from math import fabs
 import collections
 
-Register = collections.namedtuple('Register', ['name', 'data_type', 'default'])
+Register = collections.namedtuple('Register', ['name', 'data_type', 'default', 'direction'])
 Audio = collections.namedtuple('Audio', ['data_type', 'channel_count', 'dual'])
 DataType = collections.namedtuple(
     'DataType', ['word_len', 'frac_len', 'signed'])

--- a/quartus/quartus_templates.py
+++ b/quartus/quartus_templates.py
@@ -60,7 +60,7 @@ project_close
 class QuartusTemplates:
     """Generate templates for Quartus workflow."""
 
-    def __init__(self, num_custom_components, baseAddress=20):
+    def __init__(self, num_custom_components, baseAddress=40):
         """Initialize QuartusTemplates.
 
         Parameters

--- a/quartus/quartus_templates.py
+++ b/quartus/quartus_templates.py
@@ -27,8 +27,8 @@ set target_system target_name
 load_package flow
 
 if [project_exists $project] {
-    project_open $project
-    create_revision $revision
+    project_open -force -current_revision $project
+    create_revision -set_current $revision
 } else {
     project_new $project -revision ${revision} -overwrite
 }

--- a/quartus/res/soc_base_system.qsys
+++ b/quartus/res/soc_base_system.qsys
@@ -9,30 +9,12 @@
    categories="System" />
  <parameter name="bonusData"><![CDATA[bonusData 
 {
-   element FE_Qsys_AD1939_Audio_Mini_v1_0
+   element FE_Qsys_AD1939_Audio_Mini_0
    {
       datum _sortIndex
       {
          value = "8";
          type = "int";
-      }
-      datum sopceditor_expanded
-      {
-         value = "1";
-         type = "boolean";
-      }
-   }
-   element pll_using_AD1939_MCLK
-   {
-      datum _sortIndex
-      {
-         value = "5";
-         type = "int";
-      }
-      datum sopceditor_expanded
-      {
-         value = "1";
-         type = "boolean";
       }
    }
    element SystemID
@@ -140,6 +122,27 @@
       {
          value = "1";
          type = "int";
+      }
+   }
+   element pll_using_AD1939_MCLK
+   {
+      datum _sortIndex
+      {
+         value = "5";
+         type = "int";
+      }
+      datum sopceditor_expanded
+      {
+         value = "1";
+         type = "boolean";
+      }
+   }
+   element soc_base_system
+   {
+      datum _originalDeviceFamily
+      {
+         value = "Cyclone V";
+         type = "String";
       }
    }
    element soc_system
@@ -404,7 +407,7 @@
  <parameter name="hideFromIPCatalog" value="false" />
  <parameter name="lockedInterfaceDefinition" value="" />
  <parameter name="maxAdditionalLatency" value="1" />
- <parameter name="projectName" value="" />
+ <parameter name="projectName" value="DE10Nano_System.qpf" />
  <parameter name="sopcBorderPoints" value="false" />
  <parameter name="systemHash" value="0" />
  <parameter name="testBenchDutName" value="" />
@@ -428,7 +431,7 @@
    dir="end" />
  <interface
    name="ad1939_physical"
-   internal="FE_Qsys_AD1939_Audio_Mini_v1_0.connect_to_AD1939"
+   internal="FE_Qsys_AD1939_Audio_Mini_0.connect_to_AD1939"
    type="conduit"
    dir="end" />
  <interface name="clk" internal="clk_hps.clk_in" type="clock" dir="end" />
@@ -471,217 +474,10 @@
  <interface name="memory" internal="hps.memory" type="conduit" dir="end" />
  <interface name="reset" internal="clk_hps.clk_in_reset" type="reset" dir="end" />
  <module
-   name="FE_Qsys_AD1939_Audio_Mini_v1_0"
-   kind="FE_Qsys_AD1939_Audio_Mini_v1"
+   name="FE_Qsys_AD1939_Audio_Mini_0"
+   kind="FE_Qsys_AD1939_Audio_Mini"
    version="1.0"
    enabled="1" />
- <module
-   name="pll_using_AD1939_MCLK"
-   kind="altera_pll"
-   version="18.0"
-   enabled="1">
-  <parameter name="debug_print_output" value="false" />
-  <parameter name="debug_use_rbc_taf_method" value="false" />
-  <parameter name="device" value="5CSEBA6U23I7" />
-  <parameter name="device_family" value="Cyclone V" />
-  <parameter name="gui_active_clk" value="false" />
-  <parameter name="gui_actual_output_clock_frequency0" value="0 MHz" />
-  <parameter name="gui_actual_output_clock_frequency1" value="0 MHz" />
-  <parameter name="gui_actual_output_clock_frequency10" value="0 MHz" />
-  <parameter name="gui_actual_output_clock_frequency11" value="0 MHz" />
-  <parameter name="gui_actual_output_clock_frequency12" value="0 MHz" />
-  <parameter name="gui_actual_output_clock_frequency13" value="0 MHz" />
-  <parameter name="gui_actual_output_clock_frequency14" value="0 MHz" />
-  <parameter name="gui_actual_output_clock_frequency15" value="0 MHz" />
-  <parameter name="gui_actual_output_clock_frequency16" value="0 MHz" />
-  <parameter name="gui_actual_output_clock_frequency17" value="0 MHz" />
-  <parameter name="gui_actual_output_clock_frequency2" value="0 MHz" />
-  <parameter name="gui_actual_output_clock_frequency3" value="0 MHz" />
-  <parameter name="gui_actual_output_clock_frequency4" value="0 MHz" />
-  <parameter name="gui_actual_output_clock_frequency5" value="0 MHz" />
-  <parameter name="gui_actual_output_clock_frequency6" value="0 MHz" />
-  <parameter name="gui_actual_output_clock_frequency7" value="0 MHz" />
-  <parameter name="gui_actual_output_clock_frequency8" value="0 MHz" />
-  <parameter name="gui_actual_output_clock_frequency9" value="0 MHz" />
-  <parameter name="gui_actual_phase_shift0" value="0" />
-  <parameter name="gui_actual_phase_shift1" value="0" />
-  <parameter name="gui_actual_phase_shift10" value="0" />
-  <parameter name="gui_actual_phase_shift11" value="0" />
-  <parameter name="gui_actual_phase_shift12" value="0" />
-  <parameter name="gui_actual_phase_shift13" value="0" />
-  <parameter name="gui_actual_phase_shift14" value="0" />
-  <parameter name="gui_actual_phase_shift15" value="0" />
-  <parameter name="gui_actual_phase_shift16" value="0" />
-  <parameter name="gui_actual_phase_shift17" value="0" />
-  <parameter name="gui_actual_phase_shift2" value="0" />
-  <parameter name="gui_actual_phase_shift3" value="0" />
-  <parameter name="gui_actual_phase_shift4" value="0" />
-  <parameter name="gui_actual_phase_shift5" value="0" />
-  <parameter name="gui_actual_phase_shift6" value="0" />
-  <parameter name="gui_actual_phase_shift7" value="0" />
-  <parameter name="gui_actual_phase_shift8" value="0" />
-  <parameter name="gui_actual_phase_shift9" value="0" />
-  <parameter name="gui_cascade_counter0" value="false" />
-  <parameter name="gui_cascade_counter1" value="false" />
-  <parameter name="gui_cascade_counter10" value="false" />
-  <parameter name="gui_cascade_counter11" value="false" />
-  <parameter name="gui_cascade_counter12" value="false" />
-  <parameter name="gui_cascade_counter13" value="false" />
-  <parameter name="gui_cascade_counter14" value="false" />
-  <parameter name="gui_cascade_counter15" value="false" />
-  <parameter name="gui_cascade_counter16" value="false" />
-  <parameter name="gui_cascade_counter17" value="false" />
-  <parameter name="gui_cascade_counter2" value="false" />
-  <parameter name="gui_cascade_counter3" value="false" />
-  <parameter name="gui_cascade_counter4" value="false" />
-  <parameter name="gui_cascade_counter5" value="false" />
-  <parameter name="gui_cascade_counter6" value="false" />
-  <parameter name="gui_cascade_counter7" value="false" />
-  <parameter name="gui_cascade_counter8" value="false" />
-  <parameter name="gui_cascade_counter9" value="false" />
-  <parameter name="gui_cascade_outclk_index" value="0" />
-  <parameter name="gui_channel_spacing" value="0.0" />
-  <parameter name="gui_clk_bad" value="false" />
-  <parameter name="gui_device_speed_grade" value="2" />
-  <parameter name="gui_divide_factor_c0" value="1" />
-  <parameter name="gui_divide_factor_c1" value="1" />
-  <parameter name="gui_divide_factor_c10" value="1" />
-  <parameter name="gui_divide_factor_c11" value="1" />
-  <parameter name="gui_divide_factor_c12" value="1" />
-  <parameter name="gui_divide_factor_c13" value="1" />
-  <parameter name="gui_divide_factor_c14" value="1" />
-  <parameter name="gui_divide_factor_c15" value="1" />
-  <parameter name="gui_divide_factor_c16" value="1" />
-  <parameter name="gui_divide_factor_c17" value="1" />
-  <parameter name="gui_divide_factor_c2" value="1" />
-  <parameter name="gui_divide_factor_c3" value="1" />
-  <parameter name="gui_divide_factor_c4" value="1" />
-  <parameter name="gui_divide_factor_c5" value="1" />
-  <parameter name="gui_divide_factor_c6" value="1" />
-  <parameter name="gui_divide_factor_c7" value="1" />
-  <parameter name="gui_divide_factor_c8" value="1" />
-  <parameter name="gui_divide_factor_c9" value="1" />
-  <parameter name="gui_divide_factor_n" value="1" />
-  <parameter name="gui_dps_cntr" value="C0" />
-  <parameter name="gui_dps_dir" value="Positive" />
-  <parameter name="gui_dps_num" value="1" />
-  <parameter name="gui_dsm_out_sel" value="1st_order" />
-  <parameter name="gui_duty_cycle0" value="50" />
-  <parameter name="gui_duty_cycle1" value="50" />
-  <parameter name="gui_duty_cycle10" value="50" />
-  <parameter name="gui_duty_cycle11" value="50" />
-  <parameter name="gui_duty_cycle12" value="50" />
-  <parameter name="gui_duty_cycle13" value="50" />
-  <parameter name="gui_duty_cycle14" value="50" />
-  <parameter name="gui_duty_cycle15" value="50" />
-  <parameter name="gui_duty_cycle16" value="50" />
-  <parameter name="gui_duty_cycle17" value="50" />
-  <parameter name="gui_duty_cycle2" value="50" />
-  <parameter name="gui_duty_cycle3" value="50" />
-  <parameter name="gui_duty_cycle4" value="50" />
-  <parameter name="gui_duty_cycle5" value="50" />
-  <parameter name="gui_duty_cycle6" value="50" />
-  <parameter name="gui_duty_cycle7" value="50" />
-  <parameter name="gui_duty_cycle8" value="50" />
-  <parameter name="gui_duty_cycle9" value="50" />
-  <parameter name="gui_en_adv_params" value="false" />
-  <parameter name="gui_en_dps_ports" value="false" />
-  <parameter name="gui_en_phout_ports" value="false" />
-  <parameter name="gui_en_reconf" value="false" />
-  <parameter name="gui_enable_cascade_in" value="false" />
-  <parameter name="gui_enable_cascade_out" value="false" />
-  <parameter name="gui_enable_mif_dps" value="false" />
-  <parameter name="gui_feedback_clock" value="Global Clock" />
-  <parameter name="gui_frac_multiply_factor" value="1" />
-  <parameter name="gui_fractional_cout" value="32" />
-  <parameter name="gui_mif_generate" value="false" />
-  <parameter name="gui_multiply_factor" value="1" />
-  <parameter name="gui_number_of_clocks" value="1" />
-  <parameter name="gui_operation_mode" value="direct" />
-  <parameter name="gui_output_clock_frequency0" value="98.304" />
-  <parameter name="gui_output_clock_frequency1" value="100.0" />
-  <parameter name="gui_output_clock_frequency10" value="100.0" />
-  <parameter name="gui_output_clock_frequency11" value="100.0" />
-  <parameter name="gui_output_clock_frequency12" value="100.0" />
-  <parameter name="gui_output_clock_frequency13" value="100.0" />
-  <parameter name="gui_output_clock_frequency14" value="100.0" />
-  <parameter name="gui_output_clock_frequency15" value="100.0" />
-  <parameter name="gui_output_clock_frequency16" value="100.0" />
-  <parameter name="gui_output_clock_frequency17" value="100.0" />
-  <parameter name="gui_output_clock_frequency2" value="100.0" />
-  <parameter name="gui_output_clock_frequency3" value="100.0" />
-  <parameter name="gui_output_clock_frequency4" value="100.0" />
-  <parameter name="gui_output_clock_frequency5" value="100.0" />
-  <parameter name="gui_output_clock_frequency6" value="100.0" />
-  <parameter name="gui_output_clock_frequency7" value="100.0" />
-  <parameter name="gui_output_clock_frequency8" value="100.0" />
-  <parameter name="gui_output_clock_frequency9" value="100.0" />
-  <parameter name="gui_phase_shift0" value="0" />
-  <parameter name="gui_phase_shift1" value="0" />
-  <parameter name="gui_phase_shift10" value="0" />
-  <parameter name="gui_phase_shift11" value="0" />
-  <parameter name="gui_phase_shift12" value="0" />
-  <parameter name="gui_phase_shift13" value="0" />
-  <parameter name="gui_phase_shift14" value="0" />
-  <parameter name="gui_phase_shift15" value="0" />
-  <parameter name="gui_phase_shift16" value="0" />
-  <parameter name="gui_phase_shift17" value="0" />
-  <parameter name="gui_phase_shift2" value="0" />
-  <parameter name="gui_phase_shift3" value="0" />
-  <parameter name="gui_phase_shift4" value="0" />
-  <parameter name="gui_phase_shift5" value="0" />
-  <parameter name="gui_phase_shift6" value="0" />
-  <parameter name="gui_phase_shift7" value="0" />
-  <parameter name="gui_phase_shift8" value="0" />
-  <parameter name="gui_phase_shift9" value="0" />
-  <parameter name="gui_phase_shift_deg0" value="0.0" />
-  <parameter name="gui_phase_shift_deg1" value="0.0" />
-  <parameter name="gui_phase_shift_deg10" value="0.0" />
-  <parameter name="gui_phase_shift_deg11" value="0.0" />
-  <parameter name="gui_phase_shift_deg12" value="0.0" />
-  <parameter name="gui_phase_shift_deg13" value="0.0" />
-  <parameter name="gui_phase_shift_deg14" value="0.0" />
-  <parameter name="gui_phase_shift_deg15" value="0.0" />
-  <parameter name="gui_phase_shift_deg16" value="0.0" />
-  <parameter name="gui_phase_shift_deg17" value="0.0" />
-  <parameter name="gui_phase_shift_deg2" value="0.0" />
-  <parameter name="gui_phase_shift_deg3" value="0.0" />
-  <parameter name="gui_phase_shift_deg4" value="0.0" />
-  <parameter name="gui_phase_shift_deg5" value="0.0" />
-  <parameter name="gui_phase_shift_deg6" value="0.0" />
-  <parameter name="gui_phase_shift_deg7" value="0.0" />
-  <parameter name="gui_phase_shift_deg8" value="0.0" />
-  <parameter name="gui_phase_shift_deg9" value="0.0" />
-  <parameter name="gui_phout_division" value="1" />
-  <parameter name="gui_pll_auto_reset" value="Off" />
-  <parameter name="gui_pll_bandwidth_preset" value="Auto" />
-  <parameter name="gui_pll_cascading_mode">Create an adjpllin signal to connect with an upstream PLL</parameter>
-  <parameter name="gui_pll_mode" value="Integer-N PLL" />
-  <parameter name="gui_ps_units0" value="ps" />
-  <parameter name="gui_ps_units1" value="ps" />
-  <parameter name="gui_ps_units10" value="ps" />
-  <parameter name="gui_ps_units11" value="ps" />
-  <parameter name="gui_ps_units12" value="ps" />
-  <parameter name="gui_ps_units13" value="ps" />
-  <parameter name="gui_ps_units14" value="ps" />
-  <parameter name="gui_ps_units15" value="ps" />
-  <parameter name="gui_ps_units16" value="ps" />
-  <parameter name="gui_ps_units17" value="ps" />
-  <parameter name="gui_ps_units2" value="ps" />
-  <parameter name="gui_ps_units3" value="ps" />
-  <parameter name="gui_ps_units4" value="ps" />
-  <parameter name="gui_ps_units5" value="ps" />
-  <parameter name="gui_ps_units6" value="ps" />
-  <parameter name="gui_ps_units7" value="ps" />
-  <parameter name="gui_ps_units8" value="ps" />
-  <parameter name="gui_ps_units9" value="ps" />
-  <parameter name="gui_refclk1_frequency" value="100.0" />
-  <parameter name="gui_refclk_switch" value="false" />
-  <parameter name="gui_reference_clock_frequency" value="12.288" />
-  <parameter name="gui_switchover_delay" value="0" />
-  <parameter name="gui_switchover_mode">Automatic Switchover</parameter>
-  <parameter name="gui_use_locked" value="false" />
- </module>
  <module
    name="SystemID"
    kind="altera_avalon_sysid_qsys"
@@ -1296,6 +1092,213 @@
   <parameter name="useShallowMemBlocks" value="false" />
   <parameter name="writable" value="true" />
  </module>
+ <module
+   name="pll_using_AD1939_MCLK"
+   kind="altera_pll"
+   version="18.0"
+   enabled="1">
+  <parameter name="debug_print_output" value="false" />
+  <parameter name="debug_use_rbc_taf_method" value="false" />
+  <parameter name="device" value="5CSEBA6U23I7" />
+  <parameter name="device_family" value="Cyclone V" />
+  <parameter name="gui_active_clk" value="false" />
+  <parameter name="gui_actual_output_clock_frequency0" value="0 MHz" />
+  <parameter name="gui_actual_output_clock_frequency1" value="0 MHz" />
+  <parameter name="gui_actual_output_clock_frequency10" value="0 MHz" />
+  <parameter name="gui_actual_output_clock_frequency11" value="0 MHz" />
+  <parameter name="gui_actual_output_clock_frequency12" value="0 MHz" />
+  <parameter name="gui_actual_output_clock_frequency13" value="0 MHz" />
+  <parameter name="gui_actual_output_clock_frequency14" value="0 MHz" />
+  <parameter name="gui_actual_output_clock_frequency15" value="0 MHz" />
+  <parameter name="gui_actual_output_clock_frequency16" value="0 MHz" />
+  <parameter name="gui_actual_output_clock_frequency17" value="0 MHz" />
+  <parameter name="gui_actual_output_clock_frequency2" value="0 MHz" />
+  <parameter name="gui_actual_output_clock_frequency3" value="0 MHz" />
+  <parameter name="gui_actual_output_clock_frequency4" value="0 MHz" />
+  <parameter name="gui_actual_output_clock_frequency5" value="0 MHz" />
+  <parameter name="gui_actual_output_clock_frequency6" value="0 MHz" />
+  <parameter name="gui_actual_output_clock_frequency7" value="0 MHz" />
+  <parameter name="gui_actual_output_clock_frequency8" value="0 MHz" />
+  <parameter name="gui_actual_output_clock_frequency9" value="0 MHz" />
+  <parameter name="gui_actual_phase_shift0" value="0" />
+  <parameter name="gui_actual_phase_shift1" value="0" />
+  <parameter name="gui_actual_phase_shift10" value="0" />
+  <parameter name="gui_actual_phase_shift11" value="0" />
+  <parameter name="gui_actual_phase_shift12" value="0" />
+  <parameter name="gui_actual_phase_shift13" value="0" />
+  <parameter name="gui_actual_phase_shift14" value="0" />
+  <parameter name="gui_actual_phase_shift15" value="0" />
+  <parameter name="gui_actual_phase_shift16" value="0" />
+  <parameter name="gui_actual_phase_shift17" value="0" />
+  <parameter name="gui_actual_phase_shift2" value="0" />
+  <parameter name="gui_actual_phase_shift3" value="0" />
+  <parameter name="gui_actual_phase_shift4" value="0" />
+  <parameter name="gui_actual_phase_shift5" value="0" />
+  <parameter name="gui_actual_phase_shift6" value="0" />
+  <parameter name="gui_actual_phase_shift7" value="0" />
+  <parameter name="gui_actual_phase_shift8" value="0" />
+  <parameter name="gui_actual_phase_shift9" value="0" />
+  <parameter name="gui_cascade_counter0" value="false" />
+  <parameter name="gui_cascade_counter1" value="false" />
+  <parameter name="gui_cascade_counter10" value="false" />
+  <parameter name="gui_cascade_counter11" value="false" />
+  <parameter name="gui_cascade_counter12" value="false" />
+  <parameter name="gui_cascade_counter13" value="false" />
+  <parameter name="gui_cascade_counter14" value="false" />
+  <parameter name="gui_cascade_counter15" value="false" />
+  <parameter name="gui_cascade_counter16" value="false" />
+  <parameter name="gui_cascade_counter17" value="false" />
+  <parameter name="gui_cascade_counter2" value="false" />
+  <parameter name="gui_cascade_counter3" value="false" />
+  <parameter name="gui_cascade_counter4" value="false" />
+  <parameter name="gui_cascade_counter5" value="false" />
+  <parameter name="gui_cascade_counter6" value="false" />
+  <parameter name="gui_cascade_counter7" value="false" />
+  <parameter name="gui_cascade_counter8" value="false" />
+  <parameter name="gui_cascade_counter9" value="false" />
+  <parameter name="gui_cascade_outclk_index" value="0" />
+  <parameter name="gui_channel_spacing" value="0.0" />
+  <parameter name="gui_clk_bad" value="false" />
+  <parameter name="gui_device_speed_grade" value="2" />
+  <parameter name="gui_divide_factor_c0" value="1" />
+  <parameter name="gui_divide_factor_c1" value="1" />
+  <parameter name="gui_divide_factor_c10" value="1" />
+  <parameter name="gui_divide_factor_c11" value="1" />
+  <parameter name="gui_divide_factor_c12" value="1" />
+  <parameter name="gui_divide_factor_c13" value="1" />
+  <parameter name="gui_divide_factor_c14" value="1" />
+  <parameter name="gui_divide_factor_c15" value="1" />
+  <parameter name="gui_divide_factor_c16" value="1" />
+  <parameter name="gui_divide_factor_c17" value="1" />
+  <parameter name="gui_divide_factor_c2" value="1" />
+  <parameter name="gui_divide_factor_c3" value="1" />
+  <parameter name="gui_divide_factor_c4" value="1" />
+  <parameter name="gui_divide_factor_c5" value="1" />
+  <parameter name="gui_divide_factor_c6" value="1" />
+  <parameter name="gui_divide_factor_c7" value="1" />
+  <parameter name="gui_divide_factor_c8" value="1" />
+  <parameter name="gui_divide_factor_c9" value="1" />
+  <parameter name="gui_divide_factor_n" value="1" />
+  <parameter name="gui_dps_cntr" value="C0" />
+  <parameter name="gui_dps_dir" value="Positive" />
+  <parameter name="gui_dps_num" value="1" />
+  <parameter name="gui_dsm_out_sel" value="1st_order" />
+  <parameter name="gui_duty_cycle0" value="50" />
+  <parameter name="gui_duty_cycle1" value="50" />
+  <parameter name="gui_duty_cycle10" value="50" />
+  <parameter name="gui_duty_cycle11" value="50" />
+  <parameter name="gui_duty_cycle12" value="50" />
+  <parameter name="gui_duty_cycle13" value="50" />
+  <parameter name="gui_duty_cycle14" value="50" />
+  <parameter name="gui_duty_cycle15" value="50" />
+  <parameter name="gui_duty_cycle16" value="50" />
+  <parameter name="gui_duty_cycle17" value="50" />
+  <parameter name="gui_duty_cycle2" value="50" />
+  <parameter name="gui_duty_cycle3" value="50" />
+  <parameter name="gui_duty_cycle4" value="50" />
+  <parameter name="gui_duty_cycle5" value="50" />
+  <parameter name="gui_duty_cycle6" value="50" />
+  <parameter name="gui_duty_cycle7" value="50" />
+  <parameter name="gui_duty_cycle8" value="50" />
+  <parameter name="gui_duty_cycle9" value="50" />
+  <parameter name="gui_en_adv_params" value="false" />
+  <parameter name="gui_en_dps_ports" value="false" />
+  <parameter name="gui_en_phout_ports" value="false" />
+  <parameter name="gui_en_reconf" value="false" />
+  <parameter name="gui_enable_cascade_in" value="false" />
+  <parameter name="gui_enable_cascade_out" value="false" />
+  <parameter name="gui_enable_mif_dps" value="false" />
+  <parameter name="gui_feedback_clock" value="Global Clock" />
+  <parameter name="gui_frac_multiply_factor" value="1" />
+  <parameter name="gui_fractional_cout" value="32" />
+  <parameter name="gui_mif_generate" value="false" />
+  <parameter name="gui_multiply_factor" value="1" />
+  <parameter name="gui_number_of_clocks" value="1" />
+  <parameter name="gui_operation_mode" value="direct" />
+  <parameter name="gui_output_clock_frequency0" value="98.304" />
+  <parameter name="gui_output_clock_frequency1" value="100.0" />
+  <parameter name="gui_output_clock_frequency10" value="100.0" />
+  <parameter name="gui_output_clock_frequency11" value="100.0" />
+  <parameter name="gui_output_clock_frequency12" value="100.0" />
+  <parameter name="gui_output_clock_frequency13" value="100.0" />
+  <parameter name="gui_output_clock_frequency14" value="100.0" />
+  <parameter name="gui_output_clock_frequency15" value="100.0" />
+  <parameter name="gui_output_clock_frequency16" value="100.0" />
+  <parameter name="gui_output_clock_frequency17" value="100.0" />
+  <parameter name="gui_output_clock_frequency2" value="100.0" />
+  <parameter name="gui_output_clock_frequency3" value="100.0" />
+  <parameter name="gui_output_clock_frequency4" value="100.0" />
+  <parameter name="gui_output_clock_frequency5" value="100.0" />
+  <parameter name="gui_output_clock_frequency6" value="100.0" />
+  <parameter name="gui_output_clock_frequency7" value="100.0" />
+  <parameter name="gui_output_clock_frequency8" value="100.0" />
+  <parameter name="gui_output_clock_frequency9" value="100.0" />
+  <parameter name="gui_phase_shift0" value="0" />
+  <parameter name="gui_phase_shift1" value="0" />
+  <parameter name="gui_phase_shift10" value="0" />
+  <parameter name="gui_phase_shift11" value="0" />
+  <parameter name="gui_phase_shift12" value="0" />
+  <parameter name="gui_phase_shift13" value="0" />
+  <parameter name="gui_phase_shift14" value="0" />
+  <parameter name="gui_phase_shift15" value="0" />
+  <parameter name="gui_phase_shift16" value="0" />
+  <parameter name="gui_phase_shift17" value="0" />
+  <parameter name="gui_phase_shift2" value="0" />
+  <parameter name="gui_phase_shift3" value="0" />
+  <parameter name="gui_phase_shift4" value="0" />
+  <parameter name="gui_phase_shift5" value="0" />
+  <parameter name="gui_phase_shift6" value="0" />
+  <parameter name="gui_phase_shift7" value="0" />
+  <parameter name="gui_phase_shift8" value="0" />
+  <parameter name="gui_phase_shift9" value="0" />
+  <parameter name="gui_phase_shift_deg0" value="0.0" />
+  <parameter name="gui_phase_shift_deg1" value="0.0" />
+  <parameter name="gui_phase_shift_deg10" value="0.0" />
+  <parameter name="gui_phase_shift_deg11" value="0.0" />
+  <parameter name="gui_phase_shift_deg12" value="0.0" />
+  <parameter name="gui_phase_shift_deg13" value="0.0" />
+  <parameter name="gui_phase_shift_deg14" value="0.0" />
+  <parameter name="gui_phase_shift_deg15" value="0.0" />
+  <parameter name="gui_phase_shift_deg16" value="0.0" />
+  <parameter name="gui_phase_shift_deg17" value="0.0" />
+  <parameter name="gui_phase_shift_deg2" value="0.0" />
+  <parameter name="gui_phase_shift_deg3" value="0.0" />
+  <parameter name="gui_phase_shift_deg4" value="0.0" />
+  <parameter name="gui_phase_shift_deg5" value="0.0" />
+  <parameter name="gui_phase_shift_deg6" value="0.0" />
+  <parameter name="gui_phase_shift_deg7" value="0.0" />
+  <parameter name="gui_phase_shift_deg8" value="0.0" />
+  <parameter name="gui_phase_shift_deg9" value="0.0" />
+  <parameter name="gui_phout_division" value="1" />
+  <parameter name="gui_pll_auto_reset" value="Off" />
+  <parameter name="gui_pll_bandwidth_preset" value="Auto" />
+  <parameter name="gui_pll_cascading_mode">Create an adjpllin signal to connect with an upstream PLL</parameter>
+  <parameter name="gui_pll_mode" value="Integer-N PLL" />
+  <parameter name="gui_ps_units0" value="ps" />
+  <parameter name="gui_ps_units1" value="ps" />
+  <parameter name="gui_ps_units10" value="ps" />
+  <parameter name="gui_ps_units11" value="ps" />
+  <parameter name="gui_ps_units12" value="ps" />
+  <parameter name="gui_ps_units13" value="ps" />
+  <parameter name="gui_ps_units14" value="ps" />
+  <parameter name="gui_ps_units15" value="ps" />
+  <parameter name="gui_ps_units16" value="ps" />
+  <parameter name="gui_ps_units17" value="ps" />
+  <parameter name="gui_ps_units2" value="ps" />
+  <parameter name="gui_ps_units3" value="ps" />
+  <parameter name="gui_ps_units4" value="ps" />
+  <parameter name="gui_ps_units5" value="ps" />
+  <parameter name="gui_ps_units6" value="ps" />
+  <parameter name="gui_ps_units7" value="ps" />
+  <parameter name="gui_ps_units8" value="ps" />
+  <parameter name="gui_ps_units9" value="ps" />
+  <parameter name="gui_refclk1_frequency" value="100.0" />
+  <parameter name="gui_refclk_switch" value="false" />
+  <parameter name="gui_reference_clock_frequency" value="12.288" />
+  <parameter name="gui_switchover_delay" value="0" />
+  <parameter name="gui_switchover_mode">Automatic Switchover</parameter>
+  <parameter name="gui_use_locked" value="false" />
+ </module>
  <connection
    kind="avalon"
    version="18.0"
@@ -1326,8 +1329,8 @@
  <connection
    kind="avalon_streaming"
    version="18.0"
-   start="FE_Qsys_AD1939_Audio_Mini_v1_0.Line_In"
-   end="FE_Qsys_AD1939_Audio_Mini_v1_0.Headphone_Out" />
+   start="FE_Qsys_AD1939_Audio_Mini_0.Line_In"
+   end="FE_Qsys_AD1939_Audio_Mini_0.Headphone_Out" />
  <connection kind="clock" version="18.0" start="clk_hps.clk" end="SystemID.clk" />
  <connection kind="clock" version="18.0" start="clk_hps.clk" end="jtag_uart.clk" />
  <connection
@@ -1339,12 +1342,12 @@
    kind="clock"
    version="18.0"
    start="clk_AD1939_ABCLK.clk"
-   end="FE_Qsys_AD1939_Audio_Mini_v1_0.clk_abclk" />
+   end="FE_Qsys_AD1939_Audio_Mini_0.clk_abclk" />
  <connection
    kind="clock"
    version="18.0"
    start="clk_AD1939_ALRCLK.clk"
-   end="FE_Qsys_AD1939_Audio_Mini_v1_0.clk_alrclk" />
+   end="FE_Qsys_AD1939_Audio_Mini_0.clk_alrclk" />
  <connection
    kind="clock"
    version="18.0"
@@ -1364,7 +1367,7 @@
    kind="clock"
    version="18.0"
    start="pll_using_AD1939_MCLK.outclk0"
-   end="FE_Qsys_AD1939_Audio_Mini_v1_0.sys_clk" />
+   end="FE_Qsys_AD1939_Audio_Mini_0.sys_clk" />
  <connection
    kind="interrupt"
    version="18.0"
@@ -1406,7 +1409,7 @@
    kind="reset"
    version="18.0"
    start="clk_hps.clk_reset"
-   end="FE_Qsys_AD1939_Audio_Mini_v1_0.sys_reset" />
+   end="FE_Qsys_AD1939_Audio_Mini_0.sys_reset" />
  <interconnectRequirement for="$system" name="qsys_mm.clockCrossingAdapter" value="HANDSHAKE" />
  <interconnectRequirement for="$system" name="qsys_mm.maxAdditionalLatency" value="1" />
 </system>

--- a/quartus/target.py
+++ b/quartus/target.py
@@ -15,7 +15,7 @@ Audiomini = Target(name='audiomini', system_name='audiomini_system', device_fami
                    device='5CSEBA6U23I7', base_qsys_file='soc_base_system.qsys', base_proj_tcl_file='audiomini_proj.tcl',
                    files_list=['Audiomini.vhd',
                                'audiomini_system/synthesis/audiomini_system.qip'],
-                   top_level_vhdl_file='Audiomini.vhd', original_system='soc_system', base_address='20', axi_master_name='hps.h2f_lw_axi_master',
+                   top_level_vhdl_file='Audiomini.vhd', original_system='soc_system', base_address='40', axi_master_name='hps.h2f_lw_axi_master',
                    audio_in='FE_Qsys_AD1939_Audio_Mini_0.Line_In', audio_out='FE_Qsys_AD1939_Audio_Mini_0.Headphone_Out',
                    clock_name='clk_hps'
                    )
@@ -24,7 +24,7 @@ Audioblade = Target(name='audioblade', system_name='audioblade_system', device_f
                     device='10AS066H2F34I1HG', base_qsys_file='audioblade_system.qsys', base_proj_tcl_file='audioblade_proj.tcl',
                     files_list=['audioblade.vhd', 'audioblade.sdc',
                                 'audioblade_system/audioblade_system.qip', 'pll.qsys'],
-                    top_level_vhdl_file='audioblade.vhd', original_system='som_system', base_address='20',
+                    top_level_vhdl_file='audioblade.vhd', original_system='som_system', base_address='40',
                     axi_master_name='arria10_hps_0.h2f_lw_axi_master', audio_in='FE_Qsys_AD1939_Audio_Blade_v1_0.Line_In',
                     audio_out='FE_Qsys_AD1939_Audio_Blade_v1_0.Line_Out', clock_name='clk_1'
                     )
@@ -33,7 +33,7 @@ Reflex = Target(name='reflex', system_name='reflex_system', device_family='Arria
                     device='10AS066H2F34I1HG', base_qsys_file='reflex_system.qsys', base_proj_tcl_file='reflex_proj.tcl',
                     files_list=['reflex_som.vhd',
                                 'reflex_system/reflex_system.qip', 'pll_sys.qsys', 'common/delayed_rst.vhd', 'common/sync_rst.vhd', 'common/tick_gen.vhd'],
-                    top_level_vhdl_file='reflex_som.vhd', original_system='soc_system', base_address='20',
+                    top_level_vhdl_file='reflex_som.vhd', original_system='soc_system', base_address='40',
                     axi_master_name='hps.h2f_lw_axi_master', audio_in='FE_Qsys_AD1939_Audio_Research_v1_0.Line_In',
                     audio_out='FE_Qsys_AD1939_Audio_Research_v1_0.Line_Out', clock_name='clk_hps'
                     )

--- a/quartus/target.py
+++ b/quartus/target.py
@@ -16,7 +16,7 @@ Audiomini = Target(name='audiomini', system_name='audiomini_system', device_fami
                    files_list=['Audiomini.vhd',
                                'audiomini_system/synthesis/audiomini_system.qip'],
                    top_level_vhdl_file='Audiomini.vhd', original_system='soc_system', base_address='20', axi_master_name='hps.h2f_lw_axi_master',
-                   audio_in='FE_Qsys_AD1939_Audio_Mini_v1_0.Line_In', audio_out='FE_Qsys_AD1939_Audio_Mini_v1_0.Headphone_Out',
+                   audio_in='FE_Qsys_AD1939_Audio_Mini_0.Line_In', audio_out='FE_Qsys_AD1939_Audio_Mini_0.Headphone_Out',
                    clock_name='clk_hps'
                    )
 

--- a/vgen_process_simulink_model.m
+++ b/vgen_process_simulink_model.m
@@ -122,6 +122,7 @@ disp('Creating device driver.')
 outfile = [hdlpath filesep mp.modelName '.c'];
 device_driver_cmd = python + mp.codegen_path + "/autogen_device_driver.py -c " + config_filepath ...
     + " -w " + hdlpath ;
+disp(device_driver_cmd)
 system(device_driver_cmd);
 disp(['      created device driver: ' outfile])
 


### PR DESCRIPTION
AD1939 sending 24.23 format is supported on Audiomini
Driver path in sysfs is now /sys/class/fe_devicename/fe_devicenameminor#/, where minor# is generally going to be 0
Registers no longer are assumed to have register_control in front of them, so register names in model must match model.json instead of register_control_regname

In progress on support for avalon wrapper handling registers that are outputs rather than inputs

Fixed issues with regenerating a model that has an existing project but on a new target